### PR TITLE
Update vulnerable cryptography python package

### DIFF
--- a/python/lib/dcoscli/setup.py
+++ b/python/lib/dcoscli/setup.py
@@ -69,7 +69,7 @@ setup(
         'pkginfo==1.2.1',
         'toml>=0.9, <1.0',
         'virtualenv>=13.0, <16.0',
-        'cryptography==2.0.2',
+        'cryptography==2.3',
         'sseclient==0.0.19',
         'retrying==1.3.3',
     ],


### PR DESCRIPTION
The current version has a known vulnerability.

CVE disclosure : https://nvd.nist.gov/vuln/detail/CVE-2018-10903