### PR TITLE
Remove configured clusters before integration tests

### DIFF
--- a/ci/integration-tests-linux.groovy
+++ b/ci/integration-tests-linux.groovy
@@ -38,6 +38,7 @@ pipeline {
               python3 -m venv env; \
               source env/bin/activate; \
               pip install -r requirements.txt; \
+              dcos cluster remove --all; \
               ./run_integration_tests.py --e2e-backend=dcos_launch"
           '''
         }

--- a/ci/integration-tests-mac.groovy
+++ b/ci/integration-tests-mac.groovy
@@ -41,6 +41,7 @@ pipeline {
               export PYTHONIOENCODING=utf-8; \
               pip install --upgrade pip; \
               pip install -r requirements.txt; \
+              dcos cluster remove --all; \
               ./run_integration_tests.py --e2e-backend=dcos_launch"
           '''
         }

--- a/ci/integration-tests-windows.groovy
+++ b/ci/integration-tests-windows.groovy
@@ -69,6 +69,7 @@ node('py36') {
                                 export CLI_TEST_SSH_USER=centos; \
                                 export CLI_TEST_SSH_KEY_PATH=${DCOS_TEST_SSH_KEY_PATH}; \
                                 export CLI_TEST_MASTER_PROXY=true; \
+                                dist/dcos cluster remove --all; \
                                 dist/dcos cluster setup ${DCOS_TEST_URL} \
                                     --insecure --username=${DCOS_TEST_ADMIN_USERNAME} \
                                     --password-env=DCOS_TEST_ADMIN_PASSWORD; \


### PR DESCRIPTION
This makes sure there is no leftover clusters from other builds, as these tests expect a single cluster to be configured.