### PR TITLE
0.5 Fixes table printer when rendering empty data

### DIFF
--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -361,6 +361,11 @@ def job_runs_table(runs_list):
     :type runs_list: [runs]
     :rtype: PrettyTable
     """
+    # We expect to receive a list,
+    # if not we create one from the single item.
+    if not isinstance(runs_list, (list,)):
+        runs_list = [runs_list]
+
     fields = OrderedDict([
         ('task id', lambda s: s['id']),
         ('job id', lambda s: s['jobId']),


### PR DESCRIPTION
With this commit, the command
`dcos job show runs <job-id> --run-id <run-id>` works correctly.
It was previously failing due to a type error.

https://jira.mesosphere.com/browse/DCOS_OSS-3974