### PR TITLE
Adding Metronome job queue functionality to CLI

### DIFF
--- a/python/lib/dcos/dcos/metronome.py
+++ b/python/lib/dcos/dcos/metronome.py
@@ -339,10 +339,31 @@ class Client(object):
         :rtype: None
         """
 
+        if job_id is None or run_id is None:
+            raise DCOSException(
+                "job_id and run_id are required to kill a jobrun.")
         job_id = util.normalize_marathon_id_path(job_id)
         run_id = util.normalize_marathon_id_path(run_id)
         path = '/v1/jobs{}/runs{}/actions/stop'.format(job_id, run_id)
         self._rpc.http_req(http.post, path)
+
+    def get_queued_job_runs(self, job_id):
+        """Returns the content of the launch queue,
+        including the jobruns for each job_id which should be scheduled.
+
+        :returns: a list of jobruns to launch
+        :rtype: list of dict
+        """
+        response = self._rpc.http_req(http.get, 'v1/queue')
+        if job_id is not None:
+            deployments = [
+                deployment for deployment in response.json()
+                if job_id == deployment['jobId']
+            ]
+        else:
+            deployments = response.json()
+
+        return deployments
 
     @staticmethod
     def _job_id_path_format(url_path_template, id_path):

--- a/python/lib/dcoscli/dcoscli/data/help/job.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/job.txt
@@ -47,7 +47,7 @@ Commands:
     job show runs
         Shows the successful and failure runs of a job.
     job queue
-        Print a list of currently jobruns that a queued to launch
+        Provides list of job runs that have been triggered but have not started yet.
     job history
         Provides a job run history.
 

--- a/python/lib/dcoscli/dcoscli/data/help/job.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/job.txt
@@ -18,6 +18,7 @@ Description:
         dcos job schedule remove <job-id> <schedule-id>
         dcos job schedule update <job-id> <schedule-file>
         dcos job show runs <job-id> [--run-id <run-id>][--json|--quiet]
+        dcos job queue [<job-id>][--json|--quiet]
         dcos job history <job-id> [--json|--quiet] [--failures --last]
 
 Commands:
@@ -45,6 +46,8 @@ Commands:
         Updates a schedule on a job.
     job show runs
         Shows the successful and failure runs of a job.
+    job queue
+        Print a list of currently jobruns that a queued to launch
     job history
         Provides a job run history.
 

--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -249,6 +249,10 @@ def _queue(job_id, json_flag=False, quiet=False):
     deployment_list = client.get_queued_job_runs(job_id)
 
     if not deployment_list and not json_flag:
+        if job_id:
+            msg = "There are no deployments in the queue for "
+            msg += "'{}'".format(job_id)
+            emitter.publish(msg)
         return 0
 
     if quiet:

--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -249,10 +249,6 @@ def _queue(job_id, json_flag=False, quiet=False):
     deployment_list = client.get_queued_job_runs(job_id)
 
     if not deployment_list and not json_flag:
-        msg = "There are no deployments in the queue"
-        if job_id:
-            msg += " for '{}'".format(job_id)
-        emitter.publish(msg)
         return 0
 
     if quiet:

--- a/python/lib/dcoscli/dcoscli/tables.py
+++ b/python/lib/dcoscli/dcoscli/tables.py
@@ -296,6 +296,30 @@ def job_table(job_list):
     return tb
 
 
+def job_queue_table(job_queue):
+    """Returns a PrettyTable representation of the job queue from Metronome.
+     :param job_queue: jobs with jobruns in the queue to render
+    :type job_queue: [job]
+    :rtype: PrettyTable
+    """
+    flatten_job_list = []
+    for job in job_queue:
+        job_id = job["jobId"]
+        for jobruns in job.get("runs"):
+            flatten_job_list.append(
+                {'jobId': job_id, 'jobrun_id': jobruns.get("runId")})
+
+    fields = OrderedDict([
+        ('id', lambda s: s['jobId']),
+        ('job run id', lambda s: s['jobrun_id']),
+    ])
+
+    tb = truncate_table(fields, flatten_job_list, None, sortby="ID")
+    tb.align["ID"] = 'l'
+
+    return tb
+
+
 def plugins_table(plugin_list):
     """Returns a PrettyTable representation of the plugins list from Marathon.
 

--- a/python/lib/dcoscli/tests/data/metronome/jobs/gyarados.json
+++ b/python/lib/dcoscli/tests/data/metronome/jobs/gyarados.json
@@ -1,0 +1,10 @@
+{
+  "id": "gyarados",
+  "description": "so large I do not fit",
+  "run": {
+    "cmd": "sleep 20000",
+    "cpus": 100,
+    "mem": 32,
+    "disk": 0
+  }
+}

--- a/python/lib/dcoscli/tests/fixtures/metronome.py
+++ b/python/lib/dcoscli/tests/fixtures/metronome.py
@@ -118,6 +118,19 @@ def job_history_fixture():
       }]
 
 
+def job_queue_fixture():
+    """Job queue fixture
+     :rtype: dict
+    """
+    return [
+        {
+            "jobId": "queue-job",
+            "runs": [
+                {"runId": "20180123185638P0Dxf"},
+                {"runId": "20180123185640uv3PZ"}]
+        }]
+
+
 def job_schedule_fixture():
     """Job schedule fixture
 

--- a/python/lib/dcoscli/tests/integrations/test_job.py
+++ b/python/lib/dcoscli/tests/integrations/test_job.py
@@ -113,6 +113,22 @@ def test_show_schedule_blank_jobname():
     assert stdout.decode('utf-8').startswith('Invalid subcommand usage')
 
 
+def test_show_job_queue_blank():
+    assert_command(
+        ['dcos', 'job', 'queue'],
+        stdout=b"There are no deployments in the queue\n",
+        stderr=b"",
+        returncode=0)
+
+
+def test_show_job_queue_blank_for_job():
+    assert_command(
+        ['dcos', 'job', 'queue', 'magikarp'],
+        stdout=b"There are no deployments in the queue for 'magikarp'\n",
+        stderr=b"",
+        returncode=0)
+
+
 def test_show_schedule_invalid_jobname():
     assert_command(
         ['dcos', 'job', 'schedule', 'show', 'invalid'],
@@ -188,6 +204,18 @@ def _run_job(job_id):
     assert 'Run ID:' in stdout.decode('utf-8')
 
 
+def test_show_queue():
+    with _no_schedule_instance_large_job():
+        _run_job('gyarados')
+
+        returncode, stdout, stderr = exec_command(
+            ['dcos', 'job', 'queue'])
+
+        assert returncode == 0
+        assert 'JOB RUN ID' in stdout.decode('utf-8')
+        assert 'gyarados' in stdout.decode('utf-8')
+
+
 @contextlib.contextmanager
 def _no_schedule_instance_job():
     with job('tests/data/metronome/jobs/pikachu.json',
@@ -204,6 +232,13 @@ def _schedule_instance_job():
 
 def _update_job(app_id, file_path):
     assert_command(['dcos', 'job', 'update', file_path])
+
+
+@contextlib.contextmanager
+def _no_schedule_instance_large_job():
+    with job('tests/data/metronome/jobs/gyarados.json',
+             'gyarados'):
+        yield
 
 
 def _list_jobs(app_id=None):

--- a/python/lib/dcoscli/tests/integrations/test_job.py
+++ b/python/lib/dcoscli/tests/integrations/test_job.py
@@ -116,7 +116,7 @@ def test_show_schedule_blank_jobname():
 def test_show_job_queue_blank():
     assert_command(
         ['dcos', 'job', 'queue'],
-        stdout=b"There are no deployments in the queue\n",
+        stdout=b"",
         stderr=b"",
         returncode=0)
 

--- a/python/lib/dcoscli/tests/unit/data/job_queue.txt
+++ b/python/lib/dcoscli/tests/unit/data/job_queue.txt
@@ -1,0 +1,3 @@
+ID              JOB RUN ID      
+queue-job  20180123185638P0Dxf  
+queue-job  20180123185640uv3PZ  

--- a/python/lib/dcoscli/tests/unit/test_tables.py
+++ b/python/lib/dcoscli/tests/unit/test_tables.py
@@ -19,7 +19,8 @@ from ..fixtures.metrics import (agent_metrics_node_details_fixture,
                                 agent_metrics_node_summary_fixture,
                                 agent_metrics_task_details_fixture)
 from ..fixtures.metronome import (job_history_fixture, job_list_fixture,
-                                  job_run_fixture, job_schedule_fixture)
+                                  job_queue_fixture, job_run_fixture,
+                                  job_schedule_fixture)
 from ..fixtures.node import slave_fixture
 from ..fixtures.package import package_fixture, search_result_fixture
 from ..fixtures.service import framework_fixture
@@ -102,6 +103,12 @@ def test_job_history_table():
     _test_table(tables.job_history_table,
                 job_history_fixture(),
                 'tests/unit/data/job_history.txt')
+
+
+def test_job_queue_table():
+    _test_table(tables.job_queue_table,
+                job_queue_fixture(),
+                'tests/unit/data/job_queue.txt')
 
 
 def test_job_schedule_table():


### PR DESCRIPTION
command:   `job queue`, `job queue startdeadline`, `job queue --json`, `job queue -q`

```
dcos job queue 
ID                         JOB RUN ID              
startdeadline  /startdeadline/201801172321181BlLt  
```

```
 dcos job queue --json
[
  {
    "jobId": "startdeadline",
    "runs": [
      {
        "runId": "/startdeadline/201801172321181BlLt"
      }
    ]
  }
]
```

Originally a PR on https://github.com/dcos/dcos-cli/pull/1133
with approvals