### PR TITLE
Added DCOS_EXPERIMENTAL env var to not only work with Python 3.5.

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -21,7 +21,7 @@ if [ "$(uname)" = "Windows_NT" ]; then
 else
   BIN=bin
   EXE=
-  : ${PYTHON:=python3.5${EXE}}
+  : ${PYTHON:=python3${EXE}}
 fi
 
 BASEDIR=$( cd "$(dirname $(dirname "${0}"))" > /dev/null; pwd -P )

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -14,9 +14,12 @@ if [ ! -d "${BUILDDIR}/${VENV}" ]; then
     PYTHON_MAJOR=$(${PYTHON} -c 'import sys; print(sys.version_info[0])')
     PYTHON_MINOR=$(${PYTHON} -c 'import sys; print(sys.version_info[1])')
 
-    if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" != "5" ]; then
-        echo "Cannot find supported python version 3.5. Exiting..."
-        exit 1
+    : "${DCOS_EXPERIMENTAL:=""}"
+    if [ "${DCOS_EXPERIMENTAL}" = "" ]; then
+      if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" != "5" ]; then
+          echo "Cannot find supported python version 3.5. Exiting..."
+          exit 1
+      fi
     fi
     if [ "$(uname)" = "Windows_NT" ]; then
       if [ ! "$(command -v ${VIRTUALENV})" ]; then

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -3,6 +3,7 @@ tox>=2.2, <3.0
 wheel>=0.24.0, <1.0
 pytest>=2.9.1
 teamcity-messages>=1.20
-PyInstaller==3.2.1
+PyInstaller==3.2.1; python_version <= '3.5'
+PyInstaller==3.4; python_version > '3.5'
 retrying==1.3.3
 -e .. # Install the DC/OS package


### PR DESCRIPTION
Using the new `DCOS_EXPERIMENTAL` environment variable, you can use Python >= 3.5 to build the CLI.