### PR TITLE
Cleanup 'ls' integration tests

### DIFF
--- a/python/lib/dcoscli/tests/integrations/test_task.py
+++ b/python/lib/dcoscli/tests/integrations/test_task.py
@@ -202,13 +202,12 @@ def test_ls_no_params():
 
     ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').rstrip().split('\n')
-    assert len(lines) == 6
-    assert re.match('===>.*<===', lines[0])
-    assert re.match(ls_line, lines[1])
-    assert re.match('===>.*<===', lines[2])
-    assert re.match(ls_line, lines[3])
-    assert re.match('===>.*<===', lines[4])
-    assert re.match(ls_line, lines[5])
+    num_expected_lines = NUM_TASKS * 2
+
+    assert len(lines) == num_expected_lines
+    for i in range(0, num_expected_lines, 2):
+        assert re.match('===>.*<===', lines[i])
+        assert re.match(ls_line, lines[i + 1])
 
 
 def test_ls():
@@ -220,7 +219,9 @@ def test_ls():
 
     ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').rstrip().split('\n')
-    assert len(lines) == 1
+    num_expected_lines = 1
+
+    assert len(lines) == num_expected_lines
     assert re.match(ls_line, lines[0])
 
 
@@ -233,11 +234,11 @@ def test_ls_multiple_tasks():
 
     ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').rstrip().split('\n')
-    assert len(lines) == 4
-    assert re.match('===>.*<===', lines[0])
-    assert re.match(ls_line, lines[1])
-    assert re.match('===>.*<===', lines[2])
-    assert re.match(ls_line, lines[3])
+    num_expected_lines = 4
+
+    for i in range(0, num_expected_lines, 2):
+        assert re.match('===>.*<===', lines[i])
+        assert re.match(ls_line, lines[i + 1])
 
 
 def test_ls_long():
@@ -277,7 +278,9 @@ def test_ls_completed():
 
     ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').rstrip().split('\n')
-    assert len(lines) == 1
+    num_expected_lines = 1
+
+    assert len(lines) == num_expected_lines
     assert re.match(ls_line, lines[0])
 
 

--- a/python/lib/dcoscli/tests/integrations/test_task.py
+++ b/python/lib/dcoscli/tests/integrations/test_task.py
@@ -201,8 +201,8 @@ def test_ls_no_params():
     assert stderr == b''
 
     ls_line = '.*stderr.*stdout.*'
-    lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 7
+    lines = stdout.decode('utf-8').rstrip().split('\n')
+    assert len(lines) == 6
     assert re.match('===>.*<===', lines[0])
     assert re.match(ls_line, lines[1])
     assert re.match('===>.*<===', lines[2])
@@ -219,8 +219,8 @@ def test_ls():
     assert stderr == b''
 
     ls_line = '.*stderr.*stdout.*'
-    lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 2
+    lines = stdout.decode('utf-8').rstrip().split('\n')
+    assert len(lines) == 1
     assert re.match(ls_line, lines[0])
 
 
@@ -232,8 +232,8 @@ def test_ls_multiple_tasks():
     assert stderr == b''
 
     ls_line = '.*stderr.*stdout.*'
-    lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 5
+    lines = stdout.decode('utf-8').rstrip().split('\n')
+    assert len(lines) == 4
     assert re.match('===>.*<===', lines[0])
     assert re.match(ls_line, lines[1])
     assert re.match('===>.*<===', lines[2])
@@ -276,8 +276,8 @@ def test_ls_completed():
     assert stderr == b''
 
     ls_line = '.*stderr.*stdout.*'
-    lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 2
+    lines = stdout.decode('utf-8').rstrip().split('\n')
+    assert len(lines) == 1
     assert re.match(ls_line, lines[0])
 
 

--- a/python/lib/dcoscli/tests/integrations/test_task.py
+++ b/python/lib/dcoscli/tests/integrations/test_task.py
@@ -200,7 +200,7 @@ def test_ls_no_params():
     assert returncode == 0
     assert stderr == b''
 
-    ls_line = '\.ssl.*stderr.*stdout.*'
+    ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').split('\n')
     assert len(lines) == 7
     assert re.match('===>.*<===', lines[0])
@@ -218,7 +218,7 @@ def test_ls():
     assert returncode == 0
     assert stderr == b''
 
-    ls_line = '\.ssl.*stderr.*stdout.*'
+    ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').split('\n')
     assert len(lines) == 2
     assert re.match(ls_line, lines[0])
@@ -231,7 +231,7 @@ def test_ls_multiple_tasks():
     assert returncode == 0
     assert stderr == b''
 
-    ls_line = '\.ssl.*stderr.*stdout.*'
+    ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').split('\n')
     assert len(lines) == 5
     assert re.match('===>.*<===', lines[0])
@@ -275,7 +275,7 @@ def test_ls_completed():
     assert returncode == 0
     assert stderr == b''
 
-    ls_line = '\.ssl.*stderr.*stdout.*'
+    ls_line = '.*stderr.*stdout.*'
     lines = stdout.decode('utf-8').split('\n')
     assert len(lines) == 2
     assert re.match(ls_line, lines[0])


### PR DESCRIPTION
*  Cleaned up the logic for how we assert output in 'ls' integration tests.
    
    The number of output lines in the 'ls' tests depends on the number of
    tasks we are 'ls-ing' at the same time. The logic in these tests now
    reflects that so that if new test apps are added in the future, the code
    in these tests does not have to change.

*  Updated 'ls' integration tests to strip trailing newline from output.
    
    The number of lines being counted was unintuitive because of the
    trailing newline from the output. We new strip this trailing newline so
    that our assertion in the number of lines returned makes more sense.

*  Updated 'ls' integration tests to only look for 'stderr' and 'stdout'.
    
    Depending on the security mode of the cluster there might also be
    '.ssl*' and '.secret*' files in the sandbox directory in addition to the
    standard 'stderr' and 'stdout' files. The 'stderr' and 'stdout' files
    will always be present in all cases.
    
    Since we are only trying to test to make sure that ls works, it makes
    sense to only make sure that some subset of the files that we can
    guarantee to always be there will be present.
