### PR TITLE
Updated node summary JSON to omit metric if unavailable.

### DIFF
--- a/python/lib/dcoscli/dcoscli/metrics.py
+++ b/python/lib/dcoscli/dcoscli/metrics.py
@@ -95,13 +95,21 @@ def _node_summary_json(datapoints):
     :return: JSON data
     :rtype: str
     """
-    summary_datapoints = [
-        _get_datapoint(datapoints, 'cpu.total'),
-        _get_datapoint(datapoints, 'memory.total'),
-        _get_datapoint(datapoints, 'memory.free'),
-        _get_datapoint(datapoints, 'filesystem.capacity.total', {'path': '/'}),
-        _get_datapoint(datapoints, 'filesystem.capacity.used', {'path': '/'})
+
+    metrics = [
+        ['cpu.total'],
+        ['memory.total'],
+        ['memory.free'],
+        ['filesystem.capacity.total', {'path': '/'}],
+        ['filesystem.capacity.used', {'path': '/'}],
     ]
+
+    summary_datapoints = []
+    for m in metrics:
+        datapoint = _get_datapoint(datapoints, *m)
+        if datapoint is not None:
+            summary_datapoints.append(datapoint)
+
     return json.dumps(summary_datapoints)
 
 

--- a/python/lib/dcoscli/tests/integrations/test_node.py
+++ b/python/lib/dcoscli/tests/integrations/test_node.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import pytest
+import retrying
 import six
 
 import dcos.util as util
@@ -115,20 +116,28 @@ def test_node_log_invalid_lines():
 
 def test_node_metrics_agent_summary():
     first_node_id = _node()[0]['id']
-    assert_lines(
-        ['dcos', 'node', 'metrics', 'summary', first_node_id],
-        2
-    )
+
+    @retrying.retry(stop_max_delay=30 * 1000)
+    def _test_node_metrics_agent_summary():
+        assert_lines(
+            ['dcos', 'node', 'metrics', 'summary', first_node_id],
+            2
+        )
+    _test_node_metrics_agent_summary()
 
 
 def test_node_metrics_agent_summary_json():
     first_node_id = _node()[0]['id']
 
-    node_json = fetch_valid_json(
-        ['dcos', 'node', 'metrics', 'summary', first_node_id, '--json']
-    )
+    @retrying.retry(stop_max_delay=30 * 1000)
+    def _fetch_valid_json():
+        node_json = fetch_valid_json(
+            ['dcos', 'node', 'metrics', 'summary', first_node_id, '--json']
+        )
+        assert len(node_json) > 0
+        return node_json
 
-    assert len(node_json) > 0
+    node_json = _fetch_valid_json()
 
     metrics = [
         'cpu.total',
@@ -145,21 +154,29 @@ def test_node_metrics_agent_summary_json():
 
 def test_node_metrics_agent_details():
     first_node_id = _node()[0]['id']
-    assert_lines(
-        ['dcos', 'node', 'metrics', 'details', first_node_id],
-        100,
-        greater_than=True
-    )
+
+    @retrying.retry(stop_max_delay=30 * 1000)
+    def _test_node_metrics_agent_details():
+        assert_lines(
+            ['dcos', 'node', 'metrics', 'details', first_node_id],
+            100,
+            greater_than=True
+        )
+    _test_node_metrics_agent_details()
 
 
 def test_node_metrics_agent_details_json():
     first_node_id = _node()[0]['id']
 
-    node_json = fetch_valid_json(
-        ['dcos', 'node', 'metrics', 'details', first_node_id, '--json']
-    )
+    @retrying.retry(stop_max_delay=30 * 1000)
+    def _fetch_valid_json():
+        node_json = fetch_valid_json(
+            ['dcos', 'node', 'metrics', 'details', first_node_id, '--json']
+        )
+        assert len(node_json) > 100
+        return node_json
 
-    assert len(node_json) > 100
+    node_json = _fetch_valid_json()
 
     metrics = [
         'cpu.idle',

--- a/python/lib/dcoscli/tests/integrations/test_node.py
+++ b/python/lib/dcoscli/tests/integrations/test_node.py
@@ -128,9 +128,19 @@ def test_node_metrics_agent_summary_json():
         ['dcos', 'node', 'metrics', 'summary', first_node_id, '--json']
     )
 
-    names = [d['name'] for d in node_json]
-    assert names == ['cpu.total', 'memory.total', 'memory.free',
-                     'filesystem.capacity.total', 'filesystem.capacity.used']
+    assert len(node_json) > 0
+
+    metrics = [
+        'cpu.total',
+        'memory.total',
+        'memory.free',
+        'filesystem.capacity.total',
+        'filesystem.capacity.used',
+    ]
+
+    for d in node_json:
+        assert 'name' in d
+        assert d['name'] in metrics
 
 
 def test_node_metrics_agent_details():
@@ -149,8 +159,46 @@ def test_node_metrics_agent_details_json():
         ['dcos', 'node', 'metrics', 'details', first_node_id, '--json']
     )
 
-    names = [d['name'] for d in node_json]
-    assert 'system.uptime' in names
+    assert len(node_json) > 100
+
+    metrics = [
+        'cpu.idle',
+        'cpu.system',
+        'cpu.total',
+        'cpu.user',
+        'cpu.wait',
+        'filesystem.capacity.free',
+        'filesystem.capacity.total',
+        'filesystem.capacity.used',
+        'filesystem.inode.free',
+        'filesystem.inode.total',
+        'filesystem.inode.used',
+        'load.15min',
+        'load.1min',
+        'load.5min',
+        'memory.buffers',
+        'memory.cached',
+        'memory.free',
+        'memory.total',
+        'network.in',
+        'network.in.dropped',
+        'network.in.errors',
+        'network.in.packets',
+        'network.out',
+        'network.out.dropped',
+        'network.out.errors',
+        'network.out.errors',
+        'network.out.packets',
+        'process.count',
+        'swap.free',
+        'swap.total',
+        'swap.used',
+        'system.uptime',
+    ]
+
+    for d in node_json:
+        assert 'name' in d
+        assert d['name'] in metrics
 
 
 def test_node_dns():


### PR DESCRIPTION
The new telegraf based metrics service will sometimes omit metrics for
'cpu.total' if there is no load on the CPU for a node. The CLI needs to
be able to handle this case gracefully.

