### PR TITLE
PR: Print a warning when attached cluster is incorrect version

### DIFF
--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -14,7 +14,7 @@ from dcos.cosmos import get_cosmos_url
 from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import decorate_docopt_usage, cluster_version_check
 
 
 logger = util.get_logger(__name__)
@@ -44,6 +44,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
 
     for i, arg in enumerate(argv):

--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -14,7 +14,7 @@ from dcos.cosmos import get_cosmos_url
 from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage, cluster_version_check
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 
 logger = util.get_logger(__name__)

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -13,7 +13,7 @@ from dcos import cmds, emitting, http, jsonitem, marathon, mesos, options, util
 from dcos.errors import DCOSException
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage, cluster_version_check
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 
 logger = util.get_logger(__name__)

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -13,7 +13,7 @@ from dcos import cmds, emitting, http, jsonitem, marathon, mesos, options, util
 from dcos.errors import DCOSException
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import decorate_docopt_usage, cluster_version_check
 
 
 logger = util.get_logger(__name__)
@@ -29,6 +29,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("marathon"),

--- a/python/lib/dcoscli/dcoscli/node/main.py
+++ b/python/lib/dcoscli/dcoscli/node/main.py
@@ -12,7 +12,7 @@ from dcos.cosmos import get_cosmos_url
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, metrics, tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import confirm, decorate_docopt_usage, cluster_version_check
+from dcoscli.util import cluster_version_check, confirm, decorate_docopt_usage
 
 
 logger = util.get_logger(__name__)

--- a/python/lib/dcoscli/dcoscli/node/main.py
+++ b/python/lib/dcoscli/dcoscli/node/main.py
@@ -12,7 +12,7 @@ from dcos.cosmos import get_cosmos_url
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, metrics, tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import confirm, decorate_docopt_usage
+from dcoscli.util import confirm, decorate_docopt_usage, cluster_version_check
 
 
 logger = util.get_logger(__name__)
@@ -34,6 +34,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("node"),

--- a/python/lib/dcoscli/dcoscli/package/main.py
+++ b/python/lib/dcoscli/dcoscli/package/main.py
@@ -10,7 +10,8 @@ from dcos.errors import DCOSException, DefaultError
 from dcos.package import get_package_manager
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import cluster_version_check, confirm, confirm_text, decorate_docopt_usage
+from dcoscli.util import (cluster_version_check,
+                          confirm, confirm_text, decorate_docopt_usage)
 
 logger = util.get_logger(__name__)
 

--- a/python/lib/dcoscli/dcoscli/package/main.py
+++ b/python/lib/dcoscli/dcoscli/package/main.py
@@ -10,7 +10,7 @@ from dcos.errors import DCOSException, DefaultError
 from dcos.package import get_package_manager
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import confirm, confirm_text, decorate_docopt_usage, cluster_version_check
+from dcoscli.util import cluster_version_check, confirm, confirm_text, decorate_docopt_usage
 
 logger = util.get_logger(__name__)
 

--- a/python/lib/dcoscli/dcoscli/package/main.py
+++ b/python/lib/dcoscli/dcoscli/package/main.py
@@ -10,7 +10,7 @@ from dcos.errors import DCOSException, DefaultError
 from dcos.package import get_package_manager
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import confirm, confirm_text, decorate_docopt_usage
+from dcoscli.util import confirm, confirm_text, decorate_docopt_usage, cluster_version_check
 
 logger = util.get_logger(__name__)
 
@@ -26,6 +26,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("package"),

--- a/python/lib/dcoscli/dcoscli/service/main.py
+++ b/python/lib/dcoscli/dcoscli/service/main.py
@@ -6,7 +6,7 @@ from dcos import cmds, emitting, marathon, mesos, ssh_util, subprocess, util
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage, cluster_version_check
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 from ..task import main as task_main
 

--- a/python/lib/dcoscli/dcoscli/service/main.py
+++ b/python/lib/dcoscli/dcoscli/service/main.py
@@ -6,7 +6,7 @@ from dcos import cmds, emitting, marathon, mesos, ssh_util, subprocess, util
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import decorate_docopt_usage, cluster_version_check
 
 from ..task import main as task_main
 
@@ -23,6 +23,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("service"),

--- a/python/lib/dcoscli/dcoscli/task/main.py
+++ b/python/lib/dcoscli/dcoscli/task/main.py
@@ -12,7 +12,7 @@ from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import log, tables
 from dcoscli import metrics
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage, cluster_version_check
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()

--- a/python/lib/dcoscli/dcoscli/task/main.py
+++ b/python/lib/dcoscli/dcoscli/task/main.py
@@ -12,7 +12,7 @@ from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import log, tables
 from dcoscli import metrics
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import decorate_docopt_usage, cluster_version_check
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()
@@ -83,6 +83,7 @@ def docopt_wrapper(usage, real_usage, **keywords):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     """The main function for the 'task' subcommand"""
 

--- a/python/lib/dcoscli/dcoscli/util.py
+++ b/python/lib/dcoscli/dcoscli/util.py
@@ -48,7 +48,7 @@ def cluster_version_check(func):
             return func(*args, **kwargs)
 
         version = c.get_dcos_version()
-        m = re.search(r'^(1\.[0-9]+)\D*', version)
+        m = re.match(r'^(1\.[0-9]+)\D*', version)
         if m is None:
             return func(*args, **kwargs)
 

--- a/python/lib/dcoscli/dcoscli/util.py
+++ b/python/lib/dcoscli/dcoscli/util.py
@@ -56,9 +56,9 @@ def cluster_version_check(func):
         major_version = m.group(1)
 
         if major_version != supported_version:
-            message = ("The currently attached cluster is DC/OS version {}, "
-                "this CLI is only supported for DC/OS {}."
-                ).format(major_version, supported_version)
+            message = ("The attached cluster is running DC/OS {} but this "
+                       "CLI only supports DC/OS {}."
+                       ).format(major_version, supported_version)
             emitter.publish(message)
 
         return func(*args, **kwargs)

--- a/python/lib/dcoscli/dcoscli/util.py
+++ b/python/lib/dcoscli/dcoscli/util.py
@@ -32,7 +32,7 @@ def decorate_docopt_usage(func):
 
 def cluster_version_check(func):
     """ Checks that the version of the currently attached cluster is correct
-    for this version of the CLI. If not, it prints a warning.
+    for this version of the CLI. If not, prints a warning.
 
     :param func: function
     :type func: function

--- a/python/lib/dcoscli/dcoscli/util.py
+++ b/python/lib/dcoscli/dcoscli/util.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import docopt
 
-from dcos import emitting, errors
+from dcos import cluster, emitting, errors
 
 emitter = emitting.FlatEmitter()
 
@@ -27,6 +27,42 @@ def decorate_docopt_usage(func):
             emitter.publish(e)
             return 1
         return result
+    return wrapper
+
+
+def cluster_version_check(func):
+    """ Checks that the version of the currently attached cluster is correct
+    for this version of the CLI. If not, it prints a warning.
+
+    :param func: function
+    :type func: function
+    :return: wrapped function
+    :rtype: function
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        import re
+
+        c = cluster.get_attached_cluster()
+        if c is None:
+            return func(*args, **kwargs)
+
+        version = c.get_dcos_version()
+        m = re.search(r'^(1\.[0-9]+)\D*', version)
+        if m is None:
+            return func(*args, **kwargs)
+
+        supported_version = "1.12"
+        major_version = m.group(1)
+
+        if major_version != supported_version:
+            message = ("The currently attached cluster is DC/OS version {}, "
+                "this CLI is only supported for DC/OS {}."
+                ).format(major_version, supported_version)
+            emitter.publish(message)
+
+        return func(*args, **kwargs)
+
     return wrapper
 
 


### PR DESCRIPTION
The CLI is tied to a major version of DC/OS but gives you no feedback that you might be using it incorrectly. This PR adds a check for certain commands that are cluster specific and will print a warning if the attached cluster is not the version the CLI was made to work with.

It adds a decorator that can be used around top-level commands that interact with a cluster.

This is WIP because I'd like to get feedback on the general idea before scattering a bunch of `@cluster_version_check` calls around the codebase. And we haven't figured out where we should point users to in the warning to get more information on how to fix things.