### PR TITLE
Make package_plugin take in a python_bin_dir arg.

### DIFF
--- a/scripts/publish_plugins.py
+++ b/scripts/publish_plugins.py
@@ -15,7 +15,8 @@ platforms = ['linux', 'darwin', 'windows']
 for platform in platforms:
     plugin_path = build_path + '/' + platform + '/plugin'
 
-    package_plugin(build_path, platform)
+    python_bin_dir = os.path.join(plugin_path, "bin")
+    package_plugin(build_path, platform, python_bin_dir)
 
 
 s3_client = boto3.resource('s3', region_name='us-west-2').meta.client


### PR DESCRIPTION
Changes package_plugin to take a python_bin_dir arg that allows it to
work with the default `make binary` target and with our jenkins release
scripts