### PR TITLE
Use vendor mod when building go binary.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ install:
 
 build: off
 
-clone_folder: c:\gopath\src\github.com\dcos\dcos-core-cli
+clone_folder: c:\dcos-core-cli
 
 environment:
   GOPATH: c:\gopath
@@ -14,5 +14,6 @@ environment:
 stack: go 1.11
 
 test_script:
+  - SET GO111MODULE=on
   - mingw32-make windows
   - mingw32-make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ go: "1.11.x"
 go_import_path: github.com/dcos/dcos-core-cli
 
 env:
- - NO_DOCKER=1 GO111MODULE=off
+ - NO_DOCKER=1 GO111MODULE=on
 
 before_install:
- - go get -u github.com/golang/lint/golint
+ - env GO111MODULE=off go get -u github.com/golang/lint/golint
 
 script:
  - make

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ default:
 
 .PHONY: darwin linux windows
 darwin linux windows: docker-image
-	$(call inDocker,env GOOS=$(@) go build \
-		-tags '$(GO_BUILD_TAGS)' \
+	$(call inDocker,env GOOS=$(@) GO111MODULE=on go build \
+		-tags '$(GO_BUILD_TAGS)' -mod=vendor \
 		-o build/$(@)/dcos$($(@)_EXE) ./cmd/dcos)
 
 .PHONY: plugin


### PR DESCRIPTION
By passing -mod=vendor we make sure the vendor dependencies are being
used when building the binary.
See https://tip.golang.org/cmd/go/#hdr-Modules_and_vendoring

https://jira.mesosphere.com/browse/DCOS-43217