### PR TITLE
 Backport PR: Print a warning when attached cluster is incorrect version (#52) (#70)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bundle.zip
 Vagrantfile
 .vagrant
 .idea
+
+# useless change to make a commit to test appveyor

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ bundle.zip
 Vagrantfile
 .vagrant
 .idea
-
-# useless change to make a commit to test appveyor

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -14,7 +14,7 @@ from dcos.cosmos import get_cosmos_url
 from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 
 logger = util.get_logger(__name__)
@@ -44,6 +44,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
 
     for i, arg in enumerate(argv):

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -13,7 +13,7 @@ from dcos import cmds, emitting, http, jsonitem, marathon, mesos, options, util
 from dcos.errors import DCOSException
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 
 logger = util.get_logger(__name__)
@@ -29,6 +29,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("marathon"),

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -12,7 +12,7 @@ from dcos.cosmos import get_cosmos_url
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, metrics, tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import confirm, decorate_docopt_usage
+from dcoscli.util import cluster_version_check, confirm, decorate_docopt_usage
 
 
 logger = util.get_logger(__name__)
@@ -34,6 +34,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("node"),

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -10,7 +10,8 @@ from dcos.errors import DCOSException
 from dcos.package import get_package_manager
 from dcoscli import tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import confirm, confirm_text, decorate_docopt_usage
+from dcoscli.util import (cluster_version_check,
+                          confirm, confirm_text, decorate_docopt_usage)
 
 logger = util.get_logger(__name__)
 
@@ -26,6 +27,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("package"),

--- a/cli/dcoscli/service/main.py
+++ b/cli/dcoscli/service/main.py
@@ -6,7 +6,7 @@ from dcos import cmds, emitting, marathon, mesos, subprocess, util
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, tables
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 from ..task import main as task_main
 
@@ -23,6 +23,7 @@ def main(argv):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     args = docopt.docopt(
         default_doc("service"),

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -12,7 +12,7 @@ from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import log, tables
 from dcoscli import metrics
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import cluster_version_check, decorate_docopt_usage
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()
@@ -83,6 +83,7 @@ def docopt_wrapper(usage, real_usage, **keywords):
 
 
 @decorate_docopt_usage
+@cluster_version_check
 def _main(argv):
     """The main function for the 'task' subcommand"""
 

--- a/cli/dcoscli/util.py
+++ b/cli/dcoscli/util.py
@@ -57,7 +57,7 @@ def cluster_version_check(func):
         if m is None:
             return func(*args, **kwargs)
 
-        supported_version = "1.11"
+        supported_version = "1.10"
         major_version = m.group(1)
 
         if major_version != supported_version:

--- a/cli/dcoscli/util.py
+++ b/cli/dcoscli/util.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 import docopt
 
-from dcos import emitting
+from dcos import cluster, emitting
 
 emitter = emitting.FlatEmitter()
 
@@ -27,6 +27,42 @@ def decorate_docopt_usage(func):
             emitter.publish(e)
             return 1
         return result
+    return wrapper
+
+
+def cluster_version_check(func):
+    """ Checks that the version of the currently attached cluster is correct
+    for this version of the CLI. If not, prints a warning.
+
+    :param func: function
+    :type func: function
+    :return: wrapped function
+    :rtype: function
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        import re
+
+        c = cluster.get_attached_cluster()
+        if c is None:
+            return func(*args, **kwargs)
+
+        version = c.get_dcos_version()
+        m = re.match(r'^(1\.[0-9]+)\D*', version)
+        if m is None:
+            return func(*args, **kwargs)
+
+        supported_version = "1.11"
+        major_version = m.group(1)
+
+        if major_version != supported_version:
+            message = ("The attached cluster is running DC/OS {} but this "
+                       "CLI only supports DC/OS {}."
+                       ).format(major_version, supported_version)
+            emitter.publish(message)
+
+        return func(*args, **kwargs)
+
     return wrapper
 
 

--- a/cli/dcoscli/util.py
+++ b/cli/dcoscli/util.py
@@ -43,11 +43,16 @@ def cluster_version_check(func):
     def wrapper(*args, **kwargs):
         import re
 
-        c = cluster.get_attached_cluster()
-        if c is None:
+        attached = None
+        for c in cluster.get_clusters():
+            if c.is_attached():
+                attached = c
+                break
+
+        if attached is None:
             return func(*args, **kwargs)
 
-        version = c.get_dcos_version()
+        version = attached.get_dcos_version()
         m = re.match(r'^(1\.[0-9]+)\D*', version)
         if m is None:
             return func(*args, **kwargs)


### PR DESCRIPTION

* First iteration at adding version checks to CLI commands to warn users
that the setup they're using may not be supported.

* Modify the warning text to be closer to what it will likely look like
after we've figured out where the documentation for it will live.

* Add calls to the rest of the necessary subcommands