### PR TITLE
Change binary to push to dcos-1.11 instead of 1.12

### DIFF
--- a/scripts/publish_binaries.py
+++ b/scripts/publish_binaries.py
@@ -7,8 +7,7 @@ import sys
 import boto3
 import requests
 
-# TODO: the current DC/OS dev version (1.12) should be pulled dynamically (from the Github API?).
-version = os.environ.get("TAG_NAME") or "dcos-1.12"
+version = os.environ.get("TAG_NAME") or "dcos-1.11"
 
 s3_client = boto3.resource('s3', region_name='us-west-2').meta.client
 bucket = "downloads.dcos.io"


### PR DESCRIPTION
This is the first part of addressing https://jira.mesosphere.com/browse/DCOS_OSS-4365

We'll also need to replace it with actual `1.12-patch.x`