### PR TITLE
Update integration tests to use the 0.7 CLI

### DIFF
--- a/ci/integration-tests-linux.groovy
+++ b/ci/integration-tests-linux.groovy
@@ -41,7 +41,7 @@ pipeline {
               source env/bin/activate; \
               pip install --upgrade pip setuptools; \
               pip install -r requirements.txt; \
-              wget -O env/bin/dcos https://downloads.dcos.io/binaries/cli/linux/x86-64/latest/dcos; \
+              wget -O env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/linux/x86-64/0.7.x/dcos; \
               dcos cluster remove --all; \
               ./run_integration_tests.py --e2e-backend=dcos_launch"
           '''

--- a/ci/integration-tests-mac.groovy
+++ b/ci/integration-tests-mac.groovy
@@ -42,7 +42,7 @@ pipeline {
               export PYTHONIOENCODING=utf-8; \
               pip install --upgrade pip; \
               pip install -r requirements.txt; \
-              wget -O env/bin/dcos https://downloads.dcos.io/binaries/cli/darwin/x86-64/latest/dcos; \
+              wget -O env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/darwin/x86-64/0.7.x/dcos; \
               dcos cluster remove --all; \
               ./run_integration_tests.py --e2e-backend=dcos_launch"
           '''

--- a/ci/integration-tests-windows.groovy
+++ b/ci/integration-tests-windows.groovy
@@ -72,7 +72,7 @@ node('py36') {
                                 make python; \
                                 python scripts/plugin/package_plugin.py; \
                                 cd python/lib/dcoscli; \
-                                python -c 'import urllib.request; urllib.request.urlretrieve(\\\"https://downloads.dcos.io/binaries/cli/windows/x86-64/latest/dcos.exe\\\", \\\"dist/dcos.exe\\\")'; \
+                                python -c 'import urllib.request; urllib.request.urlretrieve(\\\"https://downloads.dcos.io/cli/testing/binaries/dcos/windows/x86-64/0.7.x/dcos.exe\\\", \\\"dist/dcos.exe\\\")'; \
                                 dist/dcos cluster remove --all; \
                                 dist/dcos cluster setup ${DCOS_TEST_URL} --insecure; \
                                 dist/dcos plugin add ../../../build/windows/dcos-core-cli.zip; \


### PR DESCRIPTION
This update integration tests to use the latest commit of the 0.7.x DC/OS CLI.