### PR TITLE
Pinned tox's 'pytest' to 3.9.3 or earlier to avoid bug in 3.10.0 -- 1.12 backport.

### DIFF
--- a/python/lib/dcos/tox.ini
+++ b/python/lib/dcos/tox.ini
@@ -9,7 +9,7 @@ import-order-style=smarkets
 [testenv]
 deps =
   mock
-  pytest
+  pytest<=3.9.3
   pytest-cov
   teamcity-messages
 

--- a/python/lib/dcoscli/tox.ini
+++ b/python/lib/dcoscli/tox.ini
@@ -9,7 +9,7 @@ import-order-style=smarkets
 [testenv]
 deps =
   mock
-  pytest
+  pytest<=3.9.3
   pytest-cov
   pytz
   teamcity-messages


### PR DESCRIPTION
Bug reference:
https://github.com/pytest-dev/pytest/issues/4304