### PR TITLE
Pinned tox's 'pytest' to 3.9.3 or earlier to avoid bug in 3.10.0 -- 1.11 backport.

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -9,7 +9,7 @@ import-order-style=smarkets
 [testenv]
 deps =
   mock
-  pytest
+  pytest<=3.9.3
   pytest-cov
   pytz
   teamcity-messages

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ import-order-style=smarkets
 [testenv]
 deps =
   mock
-  pytest
+  pytest<=3.9.3
   pytest-cov
   teamcity-messages
 


### PR DESCRIPTION
Bug reference:
https://github.com/pytest-dev/pytest/issues/4304