### PR TITLE
Normalize domains to lowercase when comparing URLs

### DIFF
--- a/python/lib/dcos/dcos/http.py
+++ b/python/lib/dcos/dcos/http.py
@@ -61,7 +61,7 @@ def _is_request_to_dcos(url, toml_config=None):
     # request should match scheme + netloc
     def _request_match(expected_url, actual_url):
         return expected_url.scheme == actual_url.scheme and \
-                    expected_url.netloc == actual_url.netloc
+                    expected_url.netloc.lower() == actual_url.netloc.lower()
 
     is_request_to_cluster = _request_match(dcos_url, parsed_url) or \
         _request_match(cosmos_url, parsed_url)

--- a/python/lib/dcos/tests/test_http.py
+++ b/python/lib/dcos/tests/test_http.py
@@ -5,6 +5,21 @@ from requests import Response
 from dcos import config, http
 
 
+def test_is_request_to_dcos():
+    toml_config = config.Toml({
+        'core': {'dcos_url': "https://example.com"}
+    })
+
+    assert http._is_request_to_dcos(
+        "https://example.com/path", toml_config=toml_config)
+
+    assert http._is_request_to_dcos(
+        "https://EXAMPLE.com/path", toml_config=toml_config)
+
+    assert not http._is_request_to_dcos(
+        "https://foo.com/path", toml_config=toml_config)
+
+
 @patch('requests.request')
 def test_request_default_timeout_without_config(requests_mock):
     timeout = True


### PR DESCRIPTION
Hostnames are case-insensitive and this caused issues with the `dcos
package install` command and CLI resources, as the auth token wasn't
being sent when the configured cluster URL and CLI resource URL had a
case mismatch on the domain.

https://jira.mesosphere.com/browse/DCOS_OSS-4501
https://jira.mesosphere.com/browse/DCOS-45391