### PR TITLE
Normalize domains to lowercase when comparing URLs

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -50,7 +50,7 @@ def _is_request_to_dcos(url, toml_config=None):
     # request should match scheme + netloc
     def _request_match(expected_url, actual_url):
         return expected_url.scheme == actual_url.scheme and \
-                    expected_url.netloc == actual_url.netloc
+                    expected_url.netloc.lower() == actual_url.netloc.lower()
 
     is_request_to_cluster = _request_match(dcos_url, parsed_url) or \
         _request_match(cosmos_url, parsed_url)


### PR DESCRIPTION
Hostnames are case-insensitive and this caused issues with the `dcos
package install` command and CLI resources, as the auth token wasn't
being sent when the configured cluster URL and CLI resource URL had a
case mismatch on the domain.

https://jira.mesosphere.com/browse/DCOS_OSS-4501
https://jira.mesosphere.com/browse/DCOS-45391