### PR TITLE
Add delay subcommand for marathon subcommand

### DIFF
--- a/python/lib/dcos/dcos/marathon.py
+++ b/python/lib/dcos/dcos/marathon.py
@@ -446,6 +446,21 @@ class Client(object):
         response = self._rpc.http_req(http.post, path, params=params)
         return response.json()
 
+    def delay_reset(self, app_id):
+        """
+        :param app_id: The app_id which is used to delete the delay
+        :return: The result of reset delay call
+        :rtype: dict | str
+        """
+        app_id = util.normalize_marathon_id_path(app_id)
+        response = self._rpc.http_req(
+            http.delete,
+            'v2/queue{}/delay'.format(app_id)
+        )
+        if response.status_code == 204:
+            return 'Delay on [{}] has been reset'.format(app_id)
+        raise DCOSHTTPException(response)
+
     def get_deployment(self, deployment_id):
         """Returns a deployment.
 

--- a/python/lib/dcos/dcos/marathon.py
+++ b/python/lib/dcos/dcos/marathon.py
@@ -446,19 +446,19 @@ class Client(object):
         response = self._rpc.http_req(http.post, path, params=params)
         return response.json()
 
-    def delay_reset(self, app_id):
+    def delay_reset(self, id):
         """
-        :param app_id: The app_id which is used to delete the delay
+        :param id: The app_id or pod_id which is used to delete the delay
         :return: The result of reset delay call
         :rtype: str
         """
-        app_id = util.normalize_marathon_id_path(app_id)
+        id = util.normalize_marathon_id_path(id)
         response = self._rpc.http_req(
             http.delete,
-            'v2/queue{}/delay'.format(app_id)
+            'v2/queue{}/delay'.format(id)
         )
         if response.status_code == 204:
-            return 'Delay on [{}] has been reset'.format(app_id)
+            return 'Delay on [{}] has been reset'.format(id)
         raise DCOSHTTPException(response)
 
     def get_deployment(self, deployment_id):

--- a/python/lib/dcos/dcos/marathon.py
+++ b/python/lib/dcos/dcos/marathon.py
@@ -450,7 +450,7 @@ class Client(object):
         """
         :param app_id: The app_id which is used to delete the delay
         :return: The result of reset delay call
-        :rtype: dict | str
+        :rtype: str
         """
         app_id = util.normalize_marathon_id_path(app_id)
         response = self._rpc.http_req(

--- a/python/lib/dcoscli/dcoscli/data/help/marathon.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/marathon.txt
@@ -17,6 +17,7 @@ Usage:
     dcos marathon app kill [--scale] [--host=<host>] <app-id>
     dcos marathon app update [--force] <app-id> [<properties>...]
     dcos marathon app version list [--max-count=<max-count>] <app-id>
+    dcos marathon delay reset <app-id>|<pod-id>
     dcos marathon deployment list [--json|--quiet] [<app-id>]
     dcos marathon deployment rollback <deployment-id>
     dcos marathon deployment stop <deployment-id>
@@ -69,6 +70,8 @@ Commands:
         Update an application.
     app version list
         List the version history of an application.
+    delay reset
+        Reset the current delay (if any) of the application.
     deployment list
         Print a list of currently deployed applications.
     deployment rollback

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -230,7 +230,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['marathon', 'delay', 'reset'],
-            arg_keys=['<app-id>', '<pod-id>'],
+            arg_keys=['<app-id>'],
             function=subcommand.delay_reset),
 
         cmds.Command(
@@ -862,16 +862,13 @@ class MarathonSubcommand(object):
         emitter.publish(versions)
         return 0
 
-    def delay_reset(self, app_id, pod_id):
+    def delay_reset(self, app_id):
         """
         :param app_id: the id of the application to reset delay
         :type app_id: str
-        :param pod_id: the Marathon ID of the pod to reset delay
-        :type pod_id: str
-        :return: process return code
         :rtype: int
         """
-        result = self._create_marathon_client().delay_reset(app_id or pod_id)
+        result = self._create_marathon_client().delay_reset(app_id)
         emitter.publish(result)
         return 0
 

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -229,6 +229,11 @@ def _cmds():
             function=subcommand.debug_details),
 
         cmds.Command(
+            hierarchy=['marathon', 'delay', 'reset'],
+            arg_keys=['<app-id>', '<pod-id>'],
+            function=subcommand.delay_reset),
+
+        cmds.Command(
             hierarchy=['marathon', 'about'],
             arg_keys=[],
             function=subcommand.about),
@@ -242,6 +247,7 @@ def _cmds():
             hierarchy=['marathon'],
             arg_keys=['--config-schema', '--info'],
             function=_marathon)
+
     ]
 
 
@@ -854,6 +860,19 @@ class MarathonSubcommand(object):
         versions = client.get_app_versions(app_id, max_count)
 
         emitter.publish(versions)
+        return 0
+
+    def delay_reset(self, app_id, pod_id):
+        """
+        :param app_id: the id of the application to reset delay
+        :type app_id: str
+        :param pod_id: the Marathon ID of the pod to reset delay
+        :type pod_id: str
+        :return: process return code
+        :rtype: int
+        """
+        result = self._create_marathon_client().delay_reset(app_id or pod_id)
+        emitter.publish(result)
         return 0
 
     def deployment_list(self, app_id, json_, quiet_=False):

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -864,9 +864,17 @@ class MarathonSubcommand(object):
 
     def delay_reset(self, app_id):
         """
-        :param app_id: the id of the application to reset delay
+        :param app_id: the id of the application to reset delay.
+                       This can be a pod_id as well.
         :type app_id: str
         :rtype: int
+
+        NOTE: This method takes ONLY one parameter `app_id` but the help menu says that
+        the delay subcommand can accept one of `app_id|pod_id`. Since this expression
+        always means that there is only one parameter, this method has only one parameter
+        too. Also because the name of the parameter is sensitive to how it was named in
+        the help menu, the argument MUST be named as `app_id` even though it actually
+        maps to `app_id|pod_id` in help menu.
         """
         result = self._create_marathon_client().delay_reset(app_id)
         emitter.publish(result)

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -869,12 +869,13 @@ class MarathonSubcommand(object):
         :type app_id: str
         :rtype: int
 
-        NOTE: This method takes ONLY one parameter `app_id` but the help menu says that
-        the delay subcommand can accept one of `app_id|pod_id`. Since this expression
-        always means that there is only one parameter, this method has only one parameter
-        too. Also because the name of the parameter is sensitive to how it was named in
-        the help menu, the argument MUST be named as `app_id` even though it actually
-        maps to `app_id|pod_id` in help menu.
+        NOTE: This method takes ONLY one parameter `app_id` but the help menu
+        says that the delay subcommand can accept one of `app_id|pod_id`.
+        Since this expression always means that there is only one parameter,
+        this method has only one parameter too. Also because the name of the
+        parameter is sensitive to how it was named in the help menu, the
+        argument MUST be named as `app_id` even though it actually maps to
+        `app_id|pod_id` in help menu.
         """
         result = self._create_marathon_client().delay_reset(app_id)
         emitter.publish(result)


### PR DESCRIPTION
JIRA issues: [DCOS_OSS-4325](https://jira.mesosphere.com/browse/DCOS_OSS-4325)

- Add new subcommand `dcos marathon delay reset` to reset the delay on a given appId or podId.

Sample responses:
```
$ dcos marathon delay reset sleep
Delay on [sleep] has been reset
$ dcos marathon delay reset /sleepasd
Error: Application /sleepasd not found in tasks queue.
```

NOTE : This should **NOT** be backported to 1.12 branch.