### PR TITLE
Improve confusing message on cluster version mismatch

### DIFF
--- a/cli/dcoscli/util.py
+++ b/cli/dcoscli/util.py
@@ -56,8 +56,8 @@ def cluster_version_check(func):
         major_version = m.group(1)
 
         if major_version != supported_version:
-            message = ("The attached cluster is running DC/OS {} but this "
-                       "CLI only supports DC/OS {}."
+            message = ("Warning: The attached cluster is running DC/OS {} "
+                       "but this CLI only supports DC/OS {}."
                        ).format(major_version, supported_version)
             emitter.publish(errors.DefaultError(message))
 


### PR DESCRIPTION
We should make it explicit that it is a warning and non-fatal.

https://jira.mesosphere.com/browse/DCOS-45804