### PR TITLE
[1.10] Fixed date string parsing.

### DIFF
--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -7,6 +7,7 @@ import textwrap
 
 from collections import OrderedDict
 
+import dateutil.parser
 import prettytable
 
 from dcos import auth, marathon, mesos, util
@@ -395,8 +396,8 @@ def _str_to_datetime(datetime_str):
     """
     if not datetime_str:
         return None
-    datetime_str = datetime_str.split('+')[0]
-    return datetime.datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%f")
+    # Used to parse ISO 8601 formatted date strings.
+    return dateutil.parser.parse(datetime_str)
 
 
 def _last_run_status(job):

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,3 +1,4 @@
+python-dateutil>=2.7.5
 sphinx>=1.3.1, <2.0
 tox>=2.2, <3.0
 wheel>=0.24.0, <1.0

--- a/cli/tests/unit/test_tables.py
+++ b/cli/tests/unit/test_tables.py
@@ -3,6 +3,7 @@ import datetime
 import mock
 import pytz
 
+from dcos.errors import DCOSException
 from dcos.mesos import Slave
 from dcoscli import tables
 
@@ -185,3 +186,21 @@ def _test_table(table_fn, fixture_fn, path):
     table = table_fn(fixture_fn)
     with open(path) as f:
         assert str(table) == f.read().strip('\n')
+
+
+def test_str_to_datetime():
+    date_fixtures = [
+        "2017-03-31T21:05:32.422+0000",
+        "2017-03-31T21:05:32.422+0700",
+        "2017-03-31T21:05:32.422-0400",
+        "2017-03-31T21:05:32.422-04:00",
+        "2017-03-31T21:05:32Z",
+        "2017-03-31T210532Z"
+    ]
+
+    for date in date_fixtures:
+        try:
+            tables._str_to_datetime(date)
+        except Exception as exception:
+            raise DCOSException("Error parsing {date}: {error}"
+                                .format(date=date, error=Exception))

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -11,6 +11,7 @@ deps =
   mock
   pytest
   pytest-cov
+  python-dateutil
   pytz
   teamcity-messages
   retrying


### PR DESCRIPTION
With this commit we fix the date string parsing in the `dcos-core-cli`
plugin to parse more combinations of the ISO 8601 standard. This issue
was seen in when the datestring had a different format than
`2017-03-30T15:50:16.187+0000`.

https://jira.mesosphere.com/browse/DCOS-45992