### PR TITLE
Fixed plugin release to include completions directory.

### DIFF
--- a/scripts/publish_plugins.py
+++ b/scripts/publish_plugins.py
@@ -19,7 +19,7 @@ platforms = ['linux', 'darwin', 'windows']
 
 for platform in platforms:
     python_bin_dir = build_path + '/' + platform + '/python'
-    package_plugin(build_path, platform, python_bin_dir)
+    package_plugin(build_path, platform, python_bin_dir, include_completions=True)
 
 
 s3_client = boto3.resource('s3', region_name='us-west-2').meta.client


### PR DESCRIPTION
With this commit we include the completion scripts when pushing the
plugins to S3 so the `bash` completions are available when downloading
the newest patch of the plugin or when autoinstalling it.