### PR TITLE
Added error message when running `dcos task <unexisting-task-ID>`.

### DIFF
--- a/python/lib/dcoscli/dcoscli/task/main.py
+++ b/python/lib/dcoscli/dcoscli/task/main.py
@@ -193,6 +193,11 @@ def _task(task, all_, completed, json_):
 
     if json_:
         emitter.publish([t.dict() for t in tasks])
+        return 0
+
+    if len(tasks) == 0 and task is not None:
+            raise DCOSException(
+                'Cannot find a task with ID containing "{}"'.format(task))
     else:
         table = tables.task_table(tasks)
         output = six.text_type(table)


### PR DESCRIPTION
Previously when running `dcos task foo-bar`, it would exit without any
output and error code. Now it exits with a proper error message and
an exit code of 1.

https://jira.mesosphere.com/browse/DCOS_OSS-2117