### PR TITLE
[1.13] Update metric names

### DIFF
--- a/python/lib/dcoscli/dcoscli/metrics.py
+++ b/python/lib/dcoscli/dcoscli/metrics.py
@@ -156,9 +156,9 @@ def _task_summary_json(datapoints):
     :rtype: str
     """
     summary_datapoints = [
-        _get_datapoint(datapoints, 'cpus.user.time'),
-        _get_datapoint(datapoints, 'mem.total'),
-        _get_datapoint(datapoints, 'disk.used')
+        _get_datapoint(datapoints, 'cpus.user_time_secs'),
+        _get_datapoint(datapoints, 'mem.total_bytes'),
+        _get_datapoint(datapoints, 'disk.used_bytes')
     ]
     return json.dumps(summary_datapoints)
 
@@ -172,19 +172,20 @@ def _task_summary_data(datapoints):
     :rtype: dict
     """
 
-    cpu_user = _get_datapoint_value(datapoints, 'cpus.user.time')
-    cpu_system = _get_datapoint_value(datapoints, 'cpus.system.time')
-    cpu_throttled = _get_datapoint_value(datapoints, 'cpus.throttled.time')
+    cpu_user = _get_datapoint_value(datapoints, 'cpus.user_time_secs')
+    cpu_system = _get_datapoint_value(datapoints, 'cpus.system_time_secs')
+    cpu_throttled = _get_datapoint_value(
+        datapoints, 'cpus.throttled_time_secs')
     cpu_used = cpu_user + cpu_system
     cpu_total = cpu_used + cpu_throttled
     cpu_used_pc = _percentage(cpu_used, cpu_total)
 
-    mem_total = _get_datapoint_value(datapoints, 'mem.limit')
-    mem_used = _get_datapoint_value(datapoints, 'mem.total')
+    mem_total = _get_datapoint_value(datapoints, 'mem.limit_bytes')
+    mem_used = _get_datapoint_value(datapoints, 'mem.total_bytes')
     mem_used_pc = _percentage(mem_used, mem_total)
 
-    disk_total = _get_datapoint_value(datapoints, 'disk.used')
-    disk_used = _get_datapoint_value(datapoints, 'disk.limit')
+    disk_total = _get_datapoint_value(datapoints, 'disk.used_bytes')
+    disk_used = _get_datapoint_value(datapoints, 'disk.limit_bytes')
     disk_used_pc = _percentage(disk_used, disk_total)
 
     return {


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-4622
The metrics upgrade from 1.11 to 1.12 resulted in updated metric names in the metrics API, which were not reflected here in the CLI which hits the metrics API for task metrics. I've tested this fix locally and it is now populating the CPU field (MEM and DISK metrics were not available in both versions to begin with so they are 0s here).

Previously:
```
CPU           MEM              DISK             
0.00 (0.00%)  0.00GiB (0.00%)  0.00GiB (0.00%)
```
Now:
```
CPU                MEM              DISK             
20534.96 (99.21%)  0.00GiB (0.00%)  0.00GiB (0.00%)
```