### PR TITLE
[1.12] Push dcos-core-cli to a "latest" endpoint

### DIFF
--- a/scripts/publish_plugins.py
+++ b/scripts/publish_plugins.py
@@ -26,5 +26,11 @@ s3_client = boto3.resource('s3', region_name='us-west-2').meta.client
 
 for platform in platforms:
     zip_file = platform + "/dcos-core-cli.zip"
-    bucket_key = "cli/{}/plugins/dcos-core-cli/{}/x86-64/dcos-core-cli-{}.zip".format(stability, platform, version)
-    s3_client.upload_file(build_path + "/" + zip_file, "downloads.dcos.io", bucket_key)
+    bucket_key_pattern = "cli/{}/plugins/dcos-core-cli/{}/x86-64/dcos-core-cli-{}.zip"
+    s3_client.upload_file(build_path + "/" + zip_file, "downloads.dcos.io", bucket_key_pattern.format(stability, platform, version))
+
+    if os.environ.get("TAG_NAME"):
+        # Update the latest endpoint if it's a tag release. There is no dedicated Jenkins build for this.
+        # This means we're assuming that one shouldn't rebuild an old tag, or if they do, they should then
+        # rebuild the real "latest" tag in order to keep the endpoint up-to-date.
+        s3_client.upload_file(build_path + "/" + zip_file, "downloads.dcos.io", bucket_key_pattern.format(stability, platform, version.rsplit('.', 1)[0] + '.latest'))


### PR DESCRIPTION
This pushes the dcos-core-cli to a new latest endpoint on each tag
release, eg.:

https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.12-patch.latest.zip

https://jira.mesosphere.com/browse/DCOS-44238