### PR TITLE
Don't publish binaries on pushes to 1.10

### DIFF
--- a/scripts/publish_binaries.py
+++ b/scripts/publish_binaries.py
@@ -7,7 +7,9 @@ import sys
 import boto3
 import requests
 
-version = os.environ.get("TAG_NAME") or "dcos-1.10"
+version = os.environ.get("TAG_NAME")
+if not version:
+    sys.exit(0)
 
 s3_client = boto3.resource('s3', region_name='us-west-2').meta.client
 bucket = "downloads.dcos.io"


### PR DESCRIPTION
Currently the dcos-1.10 bucket gets overwritten each time there is a push to the 1.10-patch.x branch.