### PR TITLE
Improved error handling of 'get_config_dir_path()'.

### DIFF
--- a/python/lib/dcos/dcos/config.py
+++ b/python/lib/dcos/dcos/config.py
@@ -122,7 +122,15 @@ def get_config_dir_path():
 
     config_dir = os.environ.get(constants.DCOS_DIR_ENV) or \
         os.path.join("~", constants.DCOS_DIR)
-    return os.path.expanduser(config_dir)
+    logger.debug("Config directory: {}".format(config_dir))
+
+    try:
+        config_dir_path = os.path.expanduser(config_dir)
+    except KeyError:
+        logger.exception("Cannot find the user's home directory, export"
+                         " 'DCOS_DIR' to specify where the parent of"
+                         " the directory '.dcos' is")
+    return config_dir_path
 
 
 def get_config(mutable=False):


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-4716
While running `dcos task exec` in a Marathon task, I got this error:
```
Traceback (most recent call last):
  File "dcoscli/main.py", line 127, in <module>
  File "dcoscli/main.py", line 21, in main
  File "dcoscli/main.py", line 80, in _main
  File "dcos/config.py", line 21, in uses_deprecated_config
  File "dcos/config.py", line 33, in get_global_config_path
  File "dcos/config.py", line 125, in get_config_dir_path
  File "posixpath.py", line 237, in expanduser
KeyError: 'getpwuid(): uid not found: 99'
I0121 09:28:16.539093     4 executor.cpp:1007] Command exited with status 255 (pid: 13)
Failed to execute script main
Traceback (most recent call last):
  File "dcoscli/main.py", line 127, in <module>
  File "dcoscli/main.py", line 21, in main
  File "dcoscli/main.py", line 80, in _main
  File "dcos/config.py", line 21, in uses_deprecated_config
  File "dcos/config.py", line 33, in get_global_config_path
  File "dcos/config.py", line 125, in get_config_dir_path
  File "posixpath.py", line 237, in expanduser
KeyError: 'getpwuid(): uid not found: 99'
```

The issue is due to a non existing config directory in the user's home directory, which is not clear from the previous error message. With this PR, we now throw a clearer exception and offer the possibility to see which value is being used.