### PR TITLE
[CI] Pass the --update flag when adding the core plugin

### DIFF
--- a/ci/integration-tests-windows.groovy
+++ b/ci/integration-tests-windows.groovy
@@ -91,7 +91,7 @@ node('py36') {
                                 PATH=$PWD/dist:$PATH; \
                                 dcos cluster remove --all; \
                                 dcos cluster setup ${DCOS_TEST_URL} --insecure; \
-                                dcos plugin add ../../../build/windows/dcos-core-cli.zip; \
+                                dcos plugin add -u ../../../build/windows/dcos-core-cli.zip; \
                                 ./env/Scripts/pytest -vv -x --durations=10 -p no:cacheprovider tests/integrations"
                             '''
                         }

--- a/scripts/run_integration_tests.py
+++ b/scripts/run_integration_tests.py
@@ -115,7 +115,7 @@ def _run_tests(cluster, admin_username, admin_password):
         exec_command(['dcos', 'cluster', 'setup', '--no-check', '--username',
                       admin_username, '--password', admin_password, master_ip])
 
-        exec_command(['dcos', 'plugin', 'add', '../build/' + sys.platform + '/dcos-core-cli.zip'])
+        exec_command(['dcos', 'plugin', 'add', '-u', '../build/' + sys.platform + '/dcos-core-cli.zip'])
 
         os.chdir("../python/lib/dcoscli")
 


### PR DESCRIPTION
Otherwise this causes the command to fail with a "dcos-core-cli is
already installed" error, as it gets installed during cluster setup now.