### PR TITLE
 Fix `dcos package install --cli` on Windows

### DIFF
--- a/python/lib/dcos/dcos/subcommand.py
+++ b/python/lib/dcos/dcos/subcommand.py
@@ -61,7 +61,12 @@ def get_package_commands(package_name):
 
     bin_dir = os.path.join(_package_dir(package_name),
                            constants.DCOS_SUBCOMMAND_ENV_SUBDIR,
-                           BIN_DIRECTORY)
+                           "bin")
+
+    if not os.path.exists(bin_dir) and util.is_windows_platform():
+        bin_dir = os.path.join(_package_dir(package_name),
+                               constants.DCOS_SUBCOMMAND_ENV_SUBDIR,
+                               "Scripts")
 
     executables = []
     for filename in os.listdir(bin_dir):

--- a/python/lib/dcoscli/tests/integrations/test_package_sanity.py
+++ b/python/lib/dcoscli/tests/integrations/test_package_sanity.py
@@ -1,0 +1,13 @@
+from dcoscli.test.common import exec_command
+
+
+def test_install_certified_packages_cli():
+    pkgs = [
+        'cassandra',
+        'kubernetes',
+    ]
+
+    for pkg in pkgs:
+        code, _, _ = exec_command(['dcos', 'package', 'install',
+                                   '--cli', '--yes', pkg])
+        assert code == 0


### PR DESCRIPTION
The baac6e0 was incomplete as
dcos/dcos-cli#1430 failed.

This adds the integration here instead and fixes the Windows issue for
kubernetes.

https://jira.mesosphere.com/browse/DCOS-47826