### PR TITLE
Added Go subcommand 'dcos node ssh'.

### DIFF
--- a/pkg/cmd/node/node.go
+++ b/pkg/cmd/node/node.go
@@ -39,6 +39,7 @@ func NewCommand(ctx api.Context) *cobra.Command {
 		newCmdNodeList(ctx),
 		newCmdNodeListComponents(ctx),
 		newCmdNodeMetrics(ctx),
+		newCmdNodeSSH(ctx),
 	)
 	return cmd
 }

--- a/pkg/cmd/node/node_ssh.go
+++ b/pkg/cmd/node/node_ssh.go
@@ -1,0 +1,136 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/dcos/dcos-cli/pkg/dcos"
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+	"github.com/dcos/dcos-core-cli/pkg/sshclient"
+
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func newCmdNodeSSH(ctx api.Context) *cobra.Command {
+	var leader, masterProxy bool
+	var mesosID, proxyIP, privateIP string
+
+	clientOpts:= sshclient.ClientOpts{
+		Input:      ctx.Input(),
+		Out:        ctx.Out(),
+		ErrOut:     ctx.ErrOut(),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "ssh <command>",
+		Short: "Establish an SSH connection to the master or agent nodes of your DC/OS cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+			clientOpts.Host, err = detectHost(leader, mesosID, privateIP)
+			if err != nil {
+				return err
+			}
+
+			clientOpts.Proxy, err = detectProxy(ctx, masterProxy, proxyIP)
+			if err != nil {
+				return err
+			}
+
+			sshClient, err := sshclient.NewClient(clientOpts, pluginutil.Logger())
+			if err != nil {
+				return err
+			}
+
+			return sshClient.Run(args)
+		},
+	}
+
+	defUser := "core"
+	cluster, err := ctx.Cluster()
+	if err == nil {
+		if dcosConfUser, ok := cluster.Config().Get("core.ssh_user").(string); ok {
+			defUser = dcosConfUser
+		}
+	}
+	cmd.Flags().BoolVar(&leader, "leader", false, "SSH into the leading master")
+	cmd.Flags().BoolVar(&masterProxy, "master-proxy", false, "Proxy the SSH connection through a master node")
+	cmd.Flags().StringVar(&mesosID, "mesos-id", "", "The agent ID of a node")
+	cmd.Flags().StringVar(&proxyIP, "proxy-ip", "", "Proxy the SSH connection through a different IP address")
+	cmd.Flags().StringVar(&privateIP, "private-ip", "", "Agent node with the provided private IP")
+	cmd.Flags().StringVar(&clientOpts.User, "user", defUser, "The SSH user")
+	cmd.Flags().StringVar(&clientOpts.Config, "config-file", "", "Path to SSH configuration file")
+	cmd.Flags().StringArrayVar(&clientOpts.SSHOptions, "option", nil, "The SSH options")
+
+	return cmd
+}
+
+func detectHost(leader bool, mesosID, privateIP string) (string, error) {
+	if privateIP != "" {
+		return privateIP, nil
+	}
+
+	c := mesosClient()
+	if leader {
+		leader, err := c.Leader()
+		if err != nil {
+			return "", err
+		}
+		if leader.IP == "" {
+			return "", fmt.Errorf("invalid leader response, missing field 'ip'")
+		}
+		return leader.IP, nil
+	}
+
+	state, err := c.State()
+	if err != nil {
+		return "", err
+	}
+	for _, agent := range state.Slaves {
+		if mesosID == agent.ID {
+			return agent.IP(), nil
+		}
+	}
+	return "", fmt.Errorf("agent '%s' not found", mesosID)
+}
+
+func detectProxy(ctx api.Context, masterProxy bool, proxyIP string) (string, error) {
+	// proxyIP is set. We check for ENV and return.
+	if proxyIP != "" {
+		if _, ok := ctx.EnvLookup("SSH_AUTH_SOCK"); ok {
+			ctx.Logger().Warn(
+				`There is no SSH_AUTH_SOCK env variable, which likely means
+				you aren't running 'ssh-agent'. 'dcos node ssh' --master-proxy/--proxy-ip
+				depends on 'ssh-agent' to safely use your private key
+				to hop between nodes in your cluster.
+				Please run 'ssh-agent', then add your private key with 'ssh-add'`,
+			)
+		}
+		return proxyIP, nil
+	}
+
+	// check if we have a proxyIP in the DC/OS config.
+	cluster, err := ctx.Cluster()
+	if err != nil {
+		return "", err
+	}
+	dcosConfProxyIP := cluster.Config().Get("core.ssh_proxy_ip")
+	if dcosConfProxyIP != nil {
+		return dcosConfProxyIP.(string), nil
+	}
+
+	// neither proxyIP nor masterProxy are set.
+	if proxyIP == "" && !masterProxy {
+		ctx.Logger().Info(
+			`If your are running this command from another network than DC/OS,
+			consider using "--master-proxy" or "--proxy-ip"`,
+		)
+		return "", nil
+	}
+
+	// masterProxy is true.
+	metadata, err := dcos.NewClient(pluginutil.HTTPClient("")).Metadata()
+	if metadata.PublicIPv4 == "" {
+		return "", fmt.Errorf(`cannot use "--master-proxy", failed to detect public IP for the master`)
+	}
+	return metadata.PublicIPv4, nil
+}

--- a/pkg/sshclient/client.go
+++ b/pkg/sshclient/client.go
@@ -1,0 +1,105 @@
+package sshclient
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Client to execute commands over SSH.
+type Client struct {
+	args   []string
+	logger *logrus.Logger
+	opts   ClientOpts
+}
+
+// ClientOpts defines all available options that can be set on a Client.
+type ClientOpts struct {
+	BinaryPath string
+	Input      io.Reader
+	Out        io.Writer
+	ErrOut     io.Writer
+	SSHOptions []string
+	Config     string
+	User       string
+	Proxy      string
+	Host       string
+}
+
+// -A	Enables forwarding of the authentication agent connection.
+// -t	Force pseudo-terminal allocation. Used to execute arbitrary screen-based programs on a remote machine.
+var baseArgs = []string{
+	"-A",
+	"-t",
+}
+
+// NewClient creates a new client to start a SSH session.
+func NewClient(opts ClientOpts, logger *logrus.Logger) (*Client, error) {
+	if opts.BinaryPath == "" {
+		var err error
+		opts.BinaryPath, err = exec.LookPath("ssh")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if opts.Input != nil {
+		opts.Input = os.Stdin
+	}
+	if opts.Out != nil {
+		opts.Out = os.Stdout
+	}
+	if opts.ErrOut != nil {
+		opts.ErrOut = os.Stderr
+	}
+
+	c := &Client{opts: opts}
+	c.logger = logger
+	c.configureSSHOptions()
+	c.configureDestination()
+
+	return c, nil
+}
+
+func (c *Client) configureSSHOptions() {
+	for _, option := range c.opts.SSHOptions {
+		c.args = append(c.args, "-o", fmt.Sprintf("%s", option))
+	}
+
+	if c.opts.Config != "" {
+		c.args = append(c.args, "-F", fmt.Sprintf("%s", c.opts.Config))
+	}
+}
+
+func (c *Client) configureDestination() {
+	c.logger.Debugf("Trying to establish connection to %s\n", c.opts.Host)
+	if c.opts.Proxy != "" {
+		c.logger.Debugf("Using %s as a proxy node\n", c.opts.Proxy)
+		c.args = append(c.args, baseArgs...)
+
+		if c.opts.Config == "" {
+			c.args = append(c.args, "-l", fmt.Sprintf("%s", c.opts.User))
+		}
+
+		c.args = append(c.args, fmt.Sprintf("%s", c.opts.Proxy))
+		c.args = append(c.args, "ssh")
+	}
+
+	c.args = append(c.args, baseArgs...)
+	c.args = append(c.args, fmt.Sprintf("%s", c.opts.Host))
+}
+
+// Run adds the optional remote command and starts the SSH session.
+func (c *Client) Run(command []string) error {
+	args := append(c.args, command...)
+	cmd := exec.Command(c.opts.BinaryPath, args...)
+	c.logger.Debugf("Running: %v\n", cmd.Args)
+
+	cmd.Stdin = c.opts.Input
+	cmd.Stdout = c.opts.Out
+	cmd.Stderr = c.opts.ErrOut
+
+	return cmd.Run()
+}


### PR DESCRIPTION
This includes a sshclient package that configures a SSH client to be
able to establish connections to all the nodes of a DC/OS cluster.