### PR TITLE
Add color support to `dcos node log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+## Next
+
+* Features
+
+  * Add color support to `dcos node log`
+  * Add a public IP field to `dcos node list`

--- a/pkg/logs/client_test.go
+++ b/pkg/logs/client_test.go
@@ -2,26 +2,96 @@ package logs
 
 import (
 	"bytes"
-	"fmt"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrintComponentLeaderNoService(t *testing.T) {
-	correctURL := "/system/v1/leader/mesos/logs/v2/component?skip=-10"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, r.URL.String())
-	}))
-	defer ts.Close()
+func TestPrintComponent(t *testing.T) {
+	infoEntry := &Entry{
+		RealtimeTimestamp: 1550515267000000,
+		Fields: EntryFields{
+			Priority: "6",
+			Message:  "info message",
+		},
+	}
 
-	var b bytes.Buffer
-	c := NewClient(pluginutil.HTTPClient(ts.URL), &b)
-	err := c.PrintComponent("/leader/mesos", "", -10, []string{}, false)
-	require.Equal(t, nil, err)
-	require.Equal(t, correctURL, strings.TrimSpace(b.String()))
+	errorEntry := &Entry{
+		RealtimeTimestamp: 1550515267000000,
+		Fields: EntryFields{
+			Priority: "3",
+			Message:  "error message",
+		},
+	}
+
+	fixtures := []struct {
+		route          string
+		service        string
+		skip           int
+		filters        []string
+		entries        []*Entry
+		colored        bool
+		expectedPath   string
+		expectedOutput string
+	}{
+		{
+			route:          "/leader/mesos",
+			skip:           -10,
+			entries:        []*Entry{infoEntry},
+			expectedPath:   "/system/v1/leader/mesos/logs/v2/component?skip=-10",
+			expectedOutput: "2019-02-18 18:41:07 UTC: info message\n",
+		},
+		{
+			route:          "/agent/fe406283-4198-4aa4-ad77-3f2a034884ee-S1",
+			skip:           5,
+			entries:        []*Entry{infoEntry},
+			expectedPath:   "/system/v1/agent/fe406283-4198-4aa4-ad77-3f2a034884ee-S1/logs/v2/component?skip=5",
+			expectedOutput: "2019-02-18 18:41:07 UTC: info message\n",
+		},
+		{
+			route:          "/leader/mesos",
+			entries:        []*Entry{infoEntry},
+			expectedPath:   "/system/v1/leader/mesos/logs/v2/component?skip=0",
+			expectedOutput: "2019-02-18 18:41:07 UTC: info message\n",
+		},
+		{
+			route:          "/leader/mesos",
+			entries:        []*Entry{infoEntry},
+			colored:        true,
+			expectedPath:   "/system/v1/leader/mesos/logs/v2/component?skip=0",
+			expectedOutput: "\x1b[0;0m2019-02-18 18:41:07 UTC: info message\x1b[0m\n",
+		},
+		{
+			route:          "/leader/mesos",
+			entries:        []*Entry{errorEntry},
+			colored:        true,
+			expectedPath:   "/system/v1/leader/mesos/logs/v2/component?skip=0",
+			expectedOutput: "\x1b[0;31m2019-02-18 18:41:07 UTC: error message\x1b[0m\n",
+		},
+	}
+
+	for _, fixture := range fixtures {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "application/json", r.Header.Get("Accept"))
+			assert.Equal(t, fixture.expectedPath, r.URL.String())
+
+			for _, entry := range fixture.entries {
+				assert.NoError(t, json.NewEncoder(w).Encode(entry))
+			}
+		}))
+
+		var b bytes.Buffer
+		c := NewClient(pluginutil.HTTPClient(ts.URL), &b)
+		c.colored = fixture.colored
+
+		err := c.PrintComponent(fixture.route, fixture.service, fixture.skip, fixture.filters, false)
+		require.Equal(t, nil, err)
+		require.Equal(t, fixture.expectedOutput, b.String())
+		ts.Close()
+	}
 }

--- a/pkg/logs/types.go
+++ b/pkg/logs/types.go
@@ -1,15 +1,15 @@
 package logs
 
-// SSEEventDataField is what is returned when subscribing to an event stream.
-type SSEEventDataField struct {
-	Fields             SSEEventFields `json:"fields"`
-	Cursor             string         `json:"cursor"`
-	MonotonicTimestamp int64          `json:"monotonic_timestamp"`
-	RealtimeTimestamp  int64          `json:"realtime_timestamp"`
+// Entry refers to a DC/OS log entry.
+type Entry struct {
+	Fields             EntryFields `json:"fields"`
+	Cursor             string      `json:"cursor"`
+	MonotonicTimestamp int64       `json:"monotonic_timestamp"`
+	RealtimeTimestamp  int64       `json:"realtime_timestamp"`
 }
 
-// SSEEventFields is part of the SSEEventDataField.
-type SSEEventFields struct {
+// EntryFields are the fields in a DC/OS log entry.
+type EntryFields struct {
 	Message          string `json:"MESSAGE"`
 	Priority         string `json:"PRIORITY"`
 	SyslogFacility   string `json:"SYSLOG_FACILITY"`


### PR DESCRIPTION
This adds color support to the command.

Logs lines are printed based on the log entry severity. Errors and higher are printed in red, Warnings in yellow, Notices in blue, Debug and Info logs are printed in gray.

https://jira.mesosphere.com/browse/DCOS_OSS-4813

Co-authored-by: Bilal Amarni <bilal.amarni@gmail.com>
Co-authored-by: Armand Grillet <armand.grillet@outlook.com>