### PR TITLE
Set TERM to 'xterm' when using task exec with '--tty'.

### DIFF
--- a/python/lib/dcos/dcos/mesos.py
+++ b/python/lib/dcos/dcos/mesos.py
@@ -1451,6 +1451,14 @@ class TaskIO(object):
                     'container'] = {
                         'type': 'MESOS',
                         'tty_info': {}}
+            message[
+                'launch_nested_container_session'][
+                    'command'][
+                        'environment'] = {
+                            'variables': [{
+                                    'name': 'TERM',
+                                    'type': 'VALUE',
+                                    'value': 'xterm'}]}
 
         req_extra_args = {
             'stream': True,


### PR DESCRIPTION
Tested manually as we cannot run integration tests that use this option.