### PR TITLE
[1.11] Set TERM to 'xterm' when using task exec with '--tty'.

### DIFF
--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -1294,6 +1294,14 @@ class TaskIO(object):
                     'container'] = {
                         'type': 'MESOS',
                         'tty_info': {}}
+            message[
+                'launch_nested_container_session'][
+                    'command'][
+                        'environment'] = {
+                            'variables': [{
+                                    'name': 'TERM',
+                                    'type': 'VALUE',
+                                    'value': 'xterm'}]}
 
         req_extra_args = {
             'stream': True,


### PR DESCRIPTION
Tested manually.