### PR TITLE
Show information when other bundle is in progress

### DIFF
--- a/pkg/diagnostics/client.go
+++ b/pkg/diagnostics/client.go
@@ -88,6 +88,8 @@ func (c *Client) Create(nodes []string) (*BundleCreateResponseJSONStruct, error)
 		var createdBundle BundleCreateResponseJSONStruct
 		err = json.NewDecoder(resp.Body).Decode(&createdBundle)
 		return &createdBundle, err
+	case 409:
+		return nil, fmt.Errorf("another bundle already in progress")
 	case 503:
 		return nil, fmt.Errorf("Requested nodes %v not found", nodes)
 	default:


### PR DESCRIPTION
Handle HTTP 409 error code and show user friendly information that another bundle is in progress.

Fixes: DCOS-49298