### PR TITLE
Skip test_killing_app

### DIFF
--- a/python/lib/dcoscli/tests/integrations/test_marathon.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon.py
@@ -328,6 +328,8 @@ def test_restarting_missing_app():
                    stderr=b"Error: App '/missing-id' does not exist\n")
 
 
+@pytest.mark.skip(
+    reason='https://jira.mesosphere.com/browse/DCOS-51820')
 def test_killing_app():
     with _zero_instance_app():
         start_app('zero-instance-app', 3)


### PR DESCRIPTION
It is failing for days, until we fix it it should be muted to let us have visibility on the other tests.

https://jira.mesosphere.com/browse/DCOS-51820