### PR TITLE
1.13 - Add dynamic autocompletion to dcos job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,23 @@ PKG=github.com/dcos/dcos-core-cli
 PKG_DIR=/go/src/$(PKG)
 IMAGE_NAME=dcos/dcos-core-cli
 
+PLATFORM?=$(shell uname | tr [A-Z] [a-z])
 windows_EXE=.exe
 
 .PHONY: default
-default:
-	@make $(shell uname | tr [A-Z] [a-z])
+default: $(PLATFORM)
 
 .PHONY: darwin linux windows
 darwin linux windows: docker-image
 	$(call inDocker,env GOOS=$(@) GO111MODULE=on go build \
 		-tags '$(GO_BUILD_TAGS)' -mod=vendor \
 		-o build/$(@)/dcos$($(@)_EXE) ./cmd/dcos)
+
+.PHONY: install
+install:
+	@make $(PLATFORM)
+	@make plugin
+	dcos plugin add -u ./build/$(PLATFORM)/dcos-core-cli.zip
 
 .PHONY: plugin
 plugin: python

--- a/completion/bash/job.sh
+++ b/completion/bash/job.sh
@@ -62,6 +62,7 @@ _dcos_job_remove() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
@@ -75,7 +76,7 @@ _dcos_job_update() {
 
 _dcos_job_kill() {
     local i command
-    
+
     if ! __dcos_default_command_parse; then
         return
     fi
@@ -90,6 +91,7 @@ _dcos_job_kill() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
@@ -113,6 +115,7 @@ _dcos_job_run() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
@@ -172,7 +175,7 @@ _dcos_job_schedule() {
 }
 
 _dcos_job_schedule_add() {
-    return
+    __dcos_complete_job_ids
 }
 
 _dcos_job_schedule_show() {
@@ -192,6 +195,7 @@ _dcos_job_schedule_show() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
@@ -199,11 +203,11 @@ _dcos_job_schedule_show() {
 }
 
 _dcos_job_schedule_remove() {
-    return
+    __dcos_complete_job_ids
 }
 
 _dcos_job_schedule_update() {
-    return
+    __dcos_complete_job_ids
 }
 
 _dcos_job_show() {
@@ -222,6 +226,7 @@ _dcos_job_show() {
             --*)
                 ;;
             *)
+                while IFS=$'\n' read -r line; do commands+=("$line"); done < <(dcos job list -q 2> /dev/null)
                 __dcos_handle_compreply "${commands[@]}"
                 ;;
         esac
@@ -250,6 +255,7 @@ _dcos_job_show_runs() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
@@ -274,6 +280,7 @@ _dcos_job_queue() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
@@ -300,8 +307,14 @@ _dcos_job_history() {
                 __dcos_handle_compreply "$flags[@]}"
                 ;;
             *)
+                __dcos_complete_job_ids
                 ;;
         esac
         return
     fi
+}
+
+__dcos_complete_job_ids() {
+    while IFS=$'\n' read -r line; do job_ids+=("$line"); done < <(dcos job list -q 2> /dev/null)
+    __dcos_handle_compreply "${job_ids[@]}"
 }

--- a/pkg/cmd/job/job_history.go
+++ b/pkg/cmd/job/job_history.go
@@ -17,7 +17,7 @@ func newCmdJobHistory(ctx api.Context) *cobra.Command {
 	var last bool
 	var failures bool
 	cmd := &cobra.Command{
-		Use:   "history",
+		Use:   "history <job-id>",
 		Short: "Provides a job run history",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/job/job_queue.go
+++ b/pkg/cmd/job/job_queue.go
@@ -15,7 +15,7 @@ func newCmdJobQueue(ctx api.Context) *cobra.Command {
 	var jsonOutput bool
 	var quietOutput bool
 	cmd := &cobra.Command{
-		Use:   "queue",
+		Use:   "queue [<job-id>]",
 		Short: "Show job runs that are queued",
 		Args:  cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/job/job_remove.go
+++ b/pkg/cmd/job/job_remove.go
@@ -9,7 +9,7 @@ import (
 func newCmdJobRemove(ctx api.Context) *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
-		Use:   "remove",
+		Use:   "remove  <job-id>",
 		Short: "Remove a job",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -21,6 +21,6 @@ func newCmdJobRemove(ctx api.Context) *cobra.Command {
 			return client.RemoveJob(args[0], force)
 		},
 	}
-	cmd.Flags().BoolVar(&force, "stop-current-job-runs", false, "Force to stopp all current runs")
+	cmd.Flags().BoolVar(&force, "stop-current-job-runs", false, "Force to stop all current runs")
 	return cmd
 }

--- a/pkg/cmd/job/job_run.go
+++ b/pkg/cmd/job/job_run.go
@@ -10,7 +10,7 @@ import (
 // newCmdClusterRun runs a given job right now.
 func newCmdJobRun(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run",
+		Use:   "run <job-id>",
 		Short: "Run a job now",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This adds completion for job IDs. There are a few commands which accept
a second argument, but this is not yet supported by our autocompletion
system.

https://jira.mesosphere.com/browse/DCOS-51539