### PR TITLE
Support SSE heartbeats

### DIFF
--- a/pkg/logs/client.go
+++ b/pkg/logs/client.go
@@ -64,6 +64,9 @@ func (c *Client) PrintComponent(route string, service string, opts Options) erro
 		defer client.Unsubscribe(events)
 
 		for msg := range events {
+			if len(msg.Data) == 0 {
+				continue
+			}
 			err := c.printEntry(msg.Data, opts)
 			if err != nil {
 				return err


### PR DESCRIPTION
dcos-log will send empty events to keep the connection alive. This makes
sure we don't fail with a JSON parsing error.