### PR TITLE
Uses job's task ID(s) when printing history with json.

### DIFF
--- a/pkg/cmd/job/job_history.go
+++ b/pkg/cmd/job/job_history.go
@@ -62,7 +62,8 @@ func newCmdJobHistory(ctx api.Context) *cobra.Command {
 			}
 
 			fmt.Fprintln(ctx.Out(), historyMessage(job, failures))
-			table := cli.NewTable(ctx.Out(), []string{"TASK ID", "STARTED", "FINISHED"})
+
+			table := cli.NewTable(ctx.Out(), []string{"RUN ID", "STARTED", "FINISHED"})
 			for _, run := range runs {
 				table.Append([]string{run.ID, run.CreatedAt, run.FinishedAt})
 			}

--- a/pkg/metronome/types.go
+++ b/pkg/metronome/types.go
@@ -103,9 +103,10 @@ type JobHistory struct {
 }
 
 type runHistory struct {
-	ID         string `json:"id"`
-	CreatedAt  string `json:"createdAt"`
-	FinishedAt string `json:"finishedAt"`
+	ID         string   `json:"id"`
+	CreatedAt  string   `json:"createdAt"`
+	FinishedAt string   `json:"finishedAt"`
+	Tasks      []string `json:"tasks"`
 }
 
 // JobHistorySummary contains statistics about past runs of a Job.


### PR DESCRIPTION
Field added in https://jira.mesosphere.com/browse/DCOS_OSS-5273