### PR TITLE
Enables task log --follow on multiple tasks.

### DIFF
--- a/pkg/logs/client.go
+++ b/pkg/logs/client.go
@@ -211,6 +211,9 @@ func (c *Client) resetColor() {
 }
 
 func httpResponseToError(resp *http.Response) error {
+	if resp.StatusCode == 204 {
+		return fmt.Errorf("no logs found", resp.StatusCode)
+	}
 	if resp.StatusCode < 400 {
 		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}


### PR DESCRIPTION
Tested by running this taks on a cluster: 

```
{
  "id": "/test-service",
  "backoffFactor": 1.15,
  "backoffSeconds": 1,
  "cmd": "while true; do hostname && sleep 120; done",
  "container": {
    "type": "DOCKER",
    "volumes": [],
    "docker": {
      "image": "ubuntu",
      "forcePullImage": false,
      "privileged": false,
      "parameters": []
    }
  },
  "cpus": 0.1,
  "disk": 0,
  "instances": 3,
  "mem": 128,
  "networks": [
    {
      "mode": "host"
    }
  ]
}
```

And ten running `build/darwin/dcos task log test-service --follow`.