### PR TITLE
[1.13] Upgrade to Python 3.7 on UNIX systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please follow your platform's instructions on how to do that.
 
 1.  [git](http://git-scm.com) must be installed to download the source
     code for the DC/OS CLI.
-2.  [python](https://www.python.org/) version 3.5.x must be installed.
+2.  [python](https://www.python.org/) version 3.7.x must be installed.
 3.  If `make env` fails you may be missing required dependencies for
     cryptography. See
     [here](https://cryptography.io/en/latest/installation/) for more

--- a/ci/build.groovy
+++ b/ci/build.groovy
@@ -33,16 +33,18 @@ pipeline {
         stage('Build Linux binary') {
           agent {
             node {
-              label 'py35'
+              label 'mesos'
               customWorkspace '/workspace'
             }
           }
 
           steps {
+
             sh '''
-              bash -exc " \
-                cd python/lib/dcoscli; \
-                make binary"
+                docker run --rm -v $PWD:/usr/src -w /usr/src \
+                    python:3.7 bash -exc " \
+                      cd python/lib/dcoscli; \
+                      make binary"
             '''
 
             sh '''
@@ -61,6 +63,7 @@ pipeline {
           steps {
             sh '''
               bash -exc " \
+                export PYTHON=python3.7; \
                 cd python/lib/dcoscli; \
                 make binary"
             '''
@@ -110,25 +113,28 @@ pipeline {
         stage('Run Linux tests') {
           agent {
             node {
-              label 'py35'
+              label 'mesos'
               customWorkspace '/workspace'
             }
           }
 
           steps {
             sh '''
-              bash -exc " \
-                cd python/lib/dcos; \
-                make env; \
-                ./env/bin/tox -e py35-syntax; \
-                ./env/bin/tox -e py35-unit"
+              docker run --rm -v $PWD:/usr/src -w /usr/src \
+                python:3.7 bash -exc " \
+                  cd python/lib/dcos; \
+                  make env; \
+                  ./env/bin/tox -e py35-syntax; \
+                  ./env/bin/tox -e py35-unit"
             '''
 
             sh '''
-              bash -exc " \
-                cd python/lib/dcoscli; \
-                make env; \
-                ./env/bin/tox -e py35-syntax"
+              docker run --rm -v $PWD:/usr/src -w /usr/src \
+                python:3.7 bash -exc " \
+                  export PYTHON=python3.7; \
+                  cd python/lib/dcoscli; \
+                  make env; \
+                  ./env/bin/tox -e py35-syntax"
             '''
           }
         }
@@ -139,6 +145,7 @@ pipeline {
           steps {
             sh '''
               bash -exc " \
+                export PYTHON=python3.7; \
                 cd python/lib/dcos; \
                 make env; \
                 ./env/bin/tox -e py35-syntax; \
@@ -147,6 +154,7 @@ pipeline {
 
             sh '''
               bash -exc " \
+                export PYTHON=python3.7; \
                 cd python/lib/dcoscli; \
                 make env; \
                 ./env/bin/tox -e py35-syntax"

--- a/ci/integration-tests-mac.groovy
+++ b/ci/integration-tests-mac.groovy
@@ -44,10 +44,11 @@ pipeline {
 
           sh '''
             bash -exc " \
+              export PYTHON=python3.7; \
               mkdir -p build/darwin; \
               make plugin; \
               cd scripts; \
-              python3 -m venv env; \
+              python3.7 -m venv env; \
               source env/bin/activate; \
               export LC_ALL=en_US.UTF-8; \
               export PYTHONIOENCODING=utf-8; \

--- a/python/bin/docker.sh
+++ b/python/bin/docker.sh
@@ -15,7 +15,7 @@ source ${CURRDIR}/common.sh
                      -e TOX=${TOX_DOCKER} \
                      -w /dcos-cli \
                      -u $(id -u ${USER}):$(id -g ${USER}) \
-                     python:3.5"}
+                     python:3.7"}
 
 for target in "${@}"; do
     ${DOCKER_RUN} make ${target}

--- a/python/bin/env.sh
+++ b/python/bin/env.sh
@@ -16,9 +16,23 @@ if [ ! -d "${BUILDDIR}/${VENV}" ]; then
 
     : "${DCOS_EXPERIMENTAL:=""}"
     if [ "${DCOS_EXPERIMENTAL}" = "" ]; then
-      if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" != "5" ]; then
-          echo "Cannot find supported python version 3.5. Exiting..."
-          exit 1
+
+      # On Windows, our build scripts rely on virtualenv instead of venv.
+      # This highlighted issues when trying to upgrade to Python 3.7.
+      # Given that the issue solved by upgrading to Python 3.7 is UNIX specific
+      # (https://jira.mesosphere.com/browse/DCOS-52180), and that we'll have the Python
+      # codebase completely removed for DC/OS 1.15, we're sticking to Python 3.5 on Windows
+      # instead of taking more time to try to upgrade to Python 3.7.
+      if [ "$(uname)" = "Windows_NT" ]; then
+        if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" != "5" ]; then
+            echo "Cannot find supported python version 3.5. Exiting..."
+            exit 1
+        fi
+      else
+        if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" != "7" ]; then
+            echo "Cannot find supported python version 3.7. Exiting..."
+            exit 1
+        fi
       fi
     fi
     if [ "$(uname)" = "Windows_NT" ]; then

--- a/python/lib/dcos/setup.py
+++ b/python/lib/dcos/setup.py
@@ -49,7 +49,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # What does your project relate to?

--- a/python/lib/dcoscli/bin/docker.sh
+++ b/python/lib/dcoscli/bin/docker.sh
@@ -15,6 +15,6 @@ source ${CURRDIR}/common.sh
                -e TOX=${TOX_DOCKER} \
                -w /dcos-cli/python/lib/dcoscli \
                -u $(id -u ${USER}):$(id -g ${USER}) \
-               python:3.5"}
+               python:3.7"}
 
 source ${BASEDIR}/../../bin/docker.sh

--- a/python/lib/dcoscli/setup.py
+++ b/python/lib/dcoscli/setup.py
@@ -49,7 +49,7 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Windows still uses Python 3.5 due to virtualenv issues.