### PR TITLE
Fix possible segfault in `node ssh` subcommand

### DIFF
--- a/pkg/cmd/node/node_ssh.go
+++ b/pkg/cmd/node/node_ssh.go
@@ -131,6 +131,9 @@ func detectProxy(ctx api.Context, masterProxy bool, proxyIP string) (string, err
 
 	// masterProxy is true.
 	metadata, err := dcos.NewClient(pluginutil.HTTPClient("")).Metadata()
+	if err != nil {
+		return "", err
+	}
 	if metadata.PublicIPv4 == "" {
 		return "", fmt.Errorf(`cannot use "--master-proxy", failed to detect public IP for the master`)
 	}


### PR DESCRIPTION
When no metadata can be retrieved for a cluster, `Metadata()` returns
nil and an error so let's check whether an error has been returned.