### PR TITLE
Send an empty process IO data on STDIN EOF

### DIFF
--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -10,7 +10,6 @@ import (
 	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/gobwas/glob"
 	mesosgo "github.com/mesos/mesos-go/api/v1/lib"
-	"github.com/mesos/mesos-go/api/v1/lib/encoding/codecs"
 	"github.com/mesos/mesos-go/api/v1/lib/httpcli"
 	"github.com/spf13/cobra"
 )
@@ -124,12 +123,7 @@ func mesosHTTPClient(ctx api.Context, agentID string) (*httpcli.Client, error) {
 				ipPort := strings.Split(a.GetPID(), "@")
 				url := fmt.Sprintf("http://%s", ipPort)
 
-				return httpcli.New(
-					httpcli.Endpoint(url),
-
-					// Use JSON over protobuf to ease logging.
-					httpcli.Codec(codecs.ByMediaType[codecs.MediaTypeJSON]),
-				), nil
+				return httpcli.New(httpcli.Endpoint(url)), nil
 			}
 		}
 		return nil, fmt.Errorf("Agent ID %s not found", agentID)
@@ -140,9 +134,6 @@ func mesosHTTPClient(ctx api.Context, agentID string) (*httpcli.Client, error) {
 	httpClient := httpcli.New(
 		httpcli.Endpoint(fmt.Sprintf("%s/slave/%s/api/v1", cluster.URL(), agentID)),
 		httpcli.Do(httpcli.With(httpcli.RoundTripper(rt))),
-
-		// Use JSON over protobuf to ease logging.
-		httpcli.Codec(codecs.ByMediaType[codecs.MediaTypeJSON]),
 	)
 	return httpClient, nil
 }

--- a/pkg/mesos/taskio.go
+++ b/pkg/mesos/taskio.go
@@ -316,7 +316,12 @@ func (t *TaskIO) attachContainerInput(ctx context.Context) error {
 
 		input := make(chan []byte)
 		go func() {
-			defer close(input)
+			defer func() {
+				// Push an empty string to indicate EOF to the server and close
+				// the input channel to signal that we are done processing input.
+				input <- []byte("")
+				close(input)
+			}()
 
 			for {
 				buf := make([]byte, 512) // not efficient to always do this


### PR DESCRIPTION
For an `ATTACH_CONTAINER_INPUT` call and when STDIN reaches EOF,
Mesos expects an empty process IO data message, as highlighted in:

https://github.com/dcos/dcos-core-cli/blob/7b67c5a369ff92d1c7776fa5f2b1560406a6d27d/python/lib/dcos/dcos/mesos.py#L1657-L1661

This is currently not done in the new attach and exec commands in Go. It
causes them to exit with an erroneous exit code in some cases. It can be
seen by reaching EOF while running a cat command for example. The
following command returns with an exit code of 137 instead of 0:

    dcos task exec -i my-app cat <input.txt

However, sending an empty process IO message turned out not to be doable in JSON,
due to mesos-go omitting the field when it's empty:

    {"type":"PROCESS_IO","process_io":{"type":"DATA","data":{"type":"STDIN"}}}

Mesos then returns:

    Error: malformed request: Expecting 'process_io.data.data' to be present

To get around this issue, we're switching to protobuf.