### PR TITLE
Print an empty array on `dcos task list --json`

### DIFF
--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -92,7 +92,7 @@ func findTasks(ctx api.Context, filters taskFilters) ([]mesos.Task, error) {
 		}
 	}
 
-	var tasks []mesos.Task
+	tasks := []mesos.Task{}
 	for _, f := range state.Frameworks {
 		for _, t := range f.Tasks {
 			if filters.Active && matchTask(t, filters.ID, g) {
@@ -107,7 +107,7 @@ func findTasks(ctx api.Context, filters taskFilters) ([]mesos.Task, error) {
 	}
 
 	if len(tasks) == 0 && filters.ID != "" {
-		return nil, fmt.Errorf("no task ID found containing '%s'", filters.ID)
+		return tasks, fmt.Errorf("no task ID found containing '%s'", filters.ID)
 	}
 	return tasks, nil
 }

--- a/pkg/cmd/task/task_list.go
+++ b/pkg/cmd/task/task_list.go
@@ -34,13 +34,9 @@ func newCmdTaskList(ctx api.Context) *cobra.Command {
 
 			tasks, err := findTasks(ctx, filters)
 			if err != nil {
-				if jsonOutput {
-					// On JSON ouput, we print an empty array instead of erroring-out.
-					// This is mainly done for backwards compatibility with the Python CLI.
-					fmt.Println("[]")
-					return nil
+				if !jsonOutput {
+					return err
 				}
-				return err
 			}
 
 			if jsonOutput {


### PR DESCRIPTION
Currently, we only print an empty array when an argument is passed to
filter tasks. We should also print an array when there are no tasks.

This is done by returning an empty slice instead of a nil slice.