### PR TITLE
Fixed dcos task exec with parent container.

### DIFF
--- a/pkg/cmd/task/task_exec.go
+++ b/pkg/cmd/task/task_exec.go
@@ -39,6 +39,12 @@ func newCmdTaskExec(ctx api.Context) *cobra.Command {
 				Value: task.Statuses[0].ContainerStatus.ContainerID.Value,
 			}
 
+			if task.Statuses[0].ContainerStatus.ContainerID.Parent != nil {
+				containerID.Parent = &mesosgo.ContainerID{
+					Value: task.Statuses[0].ContainerStatus.ContainerID.Parent.Value,
+				}
+			}
+
 			taskIO, err := mesos.NewTaskIO(containerID, mesos.TaskIOOpts{
 				Stdin:       ctx.Input(),
 				Stdout:      ctx.Out(),


### PR DESCRIPTION
This adds the parent contained ID to the container ID used by TaskIO, we have previously seen errors in the new Go codebase due to the missing root container ID (see https://jira.mesosphere.com/browse/DCOS-56057).

Tested manually.