### PR TITLE
Increase the buffer size when reading from piped stdin

### DIFF
--- a/pkg/mesos/taskio.go
+++ b/pkg/mesos/taskio.go
@@ -287,9 +287,14 @@ func (t *TaskIO) attachContainerInput() error {
 			}()
 
 			for {
-				// TODO(bamarni): investigate on why "test_task:test_attach" fails if the buffer size below
-				// is greater than 1, this might be an issue with the term package or the way we use it.
-				buf := make([]byte, 1)
+				bufLen := 512
+				if t.opts.TTY {
+					// TODO(bamarni): investigate on why "test_task:test_attach" fails if the buffer size below
+					// is greater than 1, this looks like an issue with the term package we're using, which doesn't
+					// work properly when reading more than 1 char at a time.
+					bufLen = 1
+				}
+				buf := make([]byte, bufLen)
 				n, err := t.opts.Stdin.Read(buf)
 				if _, ok := err.(term.EscapeError); ok {
 					t.cancelFunc()

--- a/pkg/mesos/taskio.go
+++ b/pkg/mesos/taskio.go
@@ -287,7 +287,10 @@ func (t *TaskIO) attachContainerInput() error {
 			}()
 
 			for {
+				// Use a buffer with a reasonable size in order to perform well when STDIN is piped and has
+				// a significant size. See https://jira.mesosphere.com/browse/DCOS_OSS-5357
 				bufLen := 512
+
 				if t.opts.TTY {
 					// TODO(bamarni): investigate on why "test_task:test_attach" fails if the buffer size below
 					// is greater than 1, this looks like an issue with the term package we're using, which doesn't


### PR DESCRIPTION
We had setup a 1 byte buffer for reading from stdin to work around an
issue with the escape proxy reader we're using. However @vespian
reported that it affects performances of the `dcos task exec` command
quite badly when the input is piped and has a significant size.

This updates the code to use a 1 byte buffer only for the terminal
use-case, and increasing it to 512 for piped input.

Running the following command with a ~50MB file showed the following
results:

    dcos task exec -i my-test sh -c "cat >/dev/null" < /path/to/big/file

Former Python command: `0.67s user 0.07s system 2% cpu 32.716 total`

With this patch: `0.34s user 0.20s system 2% cpu 24.880 total`

The Go command prior to this patch hadn't finished after 2 minutes.

https://jira.mesosphere.com/browse/DCOS_OSS-5357