### PR TITLE
Support --id when creating a group

### DIFF
--- a/python/lib/dcoscli/dcoscli/data/help/marathon.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/marathon.txt
@@ -23,7 +23,7 @@ Usage:
     dcos marathon deployment stop <deployment-id>
     dcos marathon deployment watch [--max-count=<max-count>]
                                    [--interval=<interval>] <deployment-id>
-    dcos marathon group add [<group-resource>]
+    dcos marathon group add [<group-resource>|--id=<group-id>]
     dcos marathon group list [--json]
     dcos marathon group scale [--force] <group-id> <scale-factor>
     dcos marathon group show [--group-version=<group-version>] <group-id>
@@ -137,6 +137,8 @@ Options:
         absolute or relative value. Absolute values must be in ISO8601 date
         format. Relative values must be specified as a negative integer and they
         represent the version from the currently deployed group definition.
+    --id=<group-id>
+        The group ID to add.
     -h, --help
         Print usage.
     --host=<host>

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -140,7 +140,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'add'],
-            arg_keys=['<group-resource>'],
+            arg_keys=['<group-resource>', '--id'],
             function=subcommand.group_add),
 
         cmds.Command(
@@ -475,7 +475,7 @@ class MarathonSubcommand(object):
         emitting.publish_table(emitter, groups, tables.group_table, json_)
         return 0
 
-    def group_add(self, group_resource):
+    def group_add(self, group_resource, id_):
         """
         :param group_resource: optional filename for the group resource
         :type group_resource: str
@@ -483,7 +483,10 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        group_resource = self._resource_reader.get_resource(group_resource)
+        if id_:
+            group_resource = {'id': id_}
+        else:
+            group_resource = self._resource_reader.get_resource(group_resource)
 
         client = self._create_marathon_client()
 


### PR DESCRIPTION
Currently only JSON input is supported, this makes it easier to create a
group.