### PR TITLE
Deprecate --mesos-id in some commands

### DIFF
--- a/pkg/cmd/node/node_list_components.go
+++ b/pkg/cmd/node/node_list_components.go
@@ -13,14 +13,20 @@ func newCmdNodeListComponents(ctx api.Context) *cobra.Command {
 	var leader bool
 	var mesosID string
 	cmd := &cobra.Command{
-		Use:   "list-components",
+		Use:   "list-components [<mesos-id>]",
 		Short: "Print a list of available DC/OS components on specified node",
-		Args:  cobra.NoArgs,
+		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if mesosID != "" {
+				ctx.Deprecated("The --mesos-id option is deprecated, please pass an argument instead.")
+			}
+			if len(args) == 1 {
+				mesosID = args[0]
+			}
 			if !leader && mesosID == "" {
-				return fmt.Errorf("'--leader' or '--mesos-id' must be provided")
+				return fmt.Errorf("'--leader' or '<mesos-id>' must be provided")
 			} else if leader && mesosID != "" {
-				return fmt.Errorf("unable to use leader and mesos id at the same time")
+				return fmt.Errorf("unable to use --leader and <mesos-id> at the same time")
 			}
 			return nil
 		},

--- a/pkg/cmd/node/node_log.go
+++ b/pkg/cmd/node/node_log.go
@@ -17,14 +17,20 @@ func newCmdNodeLog(ctx api.Context) *cobra.Command {
 	var lines int
 
 	cmd := &cobra.Command{
-		Use:   "log",
+		Use:   "log [<mesos-id>]",
 		Short: "Print logs for the leading master node or agent nodes",
-		Args:  cobra.NoArgs,
+		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if mesosID != "" {
+				ctx.Deprecated("The --mesos-id option is deprecated, please pass an argument instead.")
+			}
+			if len(args) == 1 {
+				mesosID = args[0]
+			}
 			if !leader && mesosID == "" {
-				return fmt.Errorf("'--leader' or '--mesos-id' must be provided")
+				return fmt.Errorf("'--leader' or '<mesos-id>' must be provided")
 			} else if leader && mesosID != "" {
-				return fmt.Errorf("unable to use leader and mesos id at the same time")
+				return fmt.Errorf("unable to use --leader and <mesos-id> at the same time")
 			}
 
 			if all {

--- a/python/lib/dcoscli/tests/integrations/test_node.py
+++ b/python/lib/dcoscli/tests/integrations/test_node.py
@@ -75,7 +75,7 @@ def test_node_table_uppercase_field_option():
 
 
 def test_node_log_empty():
-    stderr = b"Error: '--leader' or '--mesos-id' must be provided\n"
+    stderr = b"Error: '--leader' or '<mesos-id>' must be provided\n"
     assert_command(['dcos', 'node', 'log'], returncode=1, stderr=stderr)
 
 
@@ -86,14 +86,14 @@ def test_node_log_leader():
 def test_node_log_slave():
     slave_id = _node()[0]['id']
     assert_lines(
-        ['dcos', 'node', 'log', '--mesos-id={}'.format(slave_id)],
+        ['dcos', 'node', 'log', slave_id],
         10,
         greater_than=True)
 
 
 def test_node_log_missing_slave():
-    returncode, stdout, stderr = exec_command(
-        ['dcos', 'node', 'log', '--mesos-id=bogus'])
+    returncode, _, stderr = exec_command(
+        ['dcos', 'node', 'log', 'bogus'])
 
     assert returncode == 1
     assert b"'bogus' not found" in stderr


### PR DESCRIPTION
This applies to `dcos node log` and `dcos node list-components`.

https://jira.mesosphere.com/browse/DCOS-57654