### PR TITLE
Support custom escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 1.14-patch.5
+
+* Features
+
+  * Support custom escape sequences for `dcos task attach`
+
+## 1.14-patch.4
+
+* Fixes
+
+  * Enforce role by default when creating a Marathon group
+  * Improve error messages on metronome API errors
+  * Fix error when detecting a partial escape sequence
+
 ## 1.14-patch.3
 
 * Fixes

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -217,6 +217,9 @@ func newTaskIO(ctx api.Context, id string, interactive bool, tty bool, user stri
 
 	if escapeSequenceEnv, ok := ctx.EnvLookup("DCOS_TASK_ESCAPE_SEQUENCE"); ok {
 		opts.EscapeSequence, err = term.ToBytes(escapeSequenceEnv)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return mesos.NewTaskIO(containerID, opts)
 }

--- a/pkg/cmd/task/task.go
+++ b/pkg/cmd/task/task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-core-cli/pkg/mesos"
 	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+	"github.com/docker/docker/pkg/term"
 	"github.com/gobwas/glob"
 	mesosgo "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/mesos/mesos-go/api/v1/lib/httpcli"
@@ -203,7 +204,7 @@ func newTaskIO(ctx api.Context, id string, interactive bool, tty bool, user stri
 		}
 	}
 
-	return mesos.NewTaskIO(containerID, mesos.TaskIOOpts{
+	opts := mesos.TaskIOOpts{
 		Stdin:       ctx.Input(),
 		Stdout:      ctx.Out(),
 		Stderr:      ctx.ErrOut(),
@@ -212,5 +213,10 @@ func newTaskIO(ctx api.Context, id string, interactive bool, tty bool, user stri
 		User:        user,
 		Sender:      httpagent.NewSender(httpClient.Send),
 		Logger:      pluginutil.Logger(),
-	})
+	}
+
+	if escapeSequenceEnv, ok := ctx.EnvLookup("DCOS_TASK_ESCAPE_SEQUENCE"); ok {
+		opts.EscapeSequence, err = term.ToBytes(escapeSequenceEnv)
+	}
+	return mesos.NewTaskIO(containerID, opts)
 }

--- a/python/lib/dcoscli/dcoscli/test/common.py
+++ b/python/lib/dcoscli/dcoscli/test/common.py
@@ -290,7 +290,7 @@ def dcos_tempdir(copy=False):
             os.environ.pop(constants.DCOS_DIR_ENV)
 
 
-def popen_tty(cmd, shell=True):
+def popen_tty(cmd, shell=True, env=None):
     """Open a process with stdin connected to a pseudo-tty.  Returns a
 
     :param cmd: command to run
@@ -311,6 +311,7 @@ def popen_tty(cmd, shell=True):
                             stderr=subprocess.PIPE,
                             preexec_fn=os.setsid,
                             close_fds=True,
+                            env=env,
                             shell=shell)
     os.close(slave)
 

--- a/python/lib/dcoscli/tests/integrations/test_task.py
+++ b/python/lib/dcoscli/tests/integrations/test_task.py
@@ -487,6 +487,25 @@ def test_attach_partial_escape_sequence():
 
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason="'dcos task attach' not supported on Windows")
+def test_attach_custom_escape_sequence():
+    task_id = _get_task_id('cat-app')
+
+    env = os.environ.copy()
+    env["DCOS_TASK_ESCAPE_SEQUENCE"] = "ctrl-p,ctrl-r,ctrl-s"
+
+    proc, master = popen_tty('dcos task attach ' + task_id, env=env)
+    master = os.fdopen(master, 'w')
+    tty.setraw(master, when=termios.TCSANOW)
+
+    master.buffer.write(b'\x10\x12\x13')
+    master.flush()
+
+    assert proc.wait() == 0
+    master.close()
+
+
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="'dcos task attach' not supported on Windows")
 def test_attach_no_tty():
     task_id = _get_task_id('ls-app')
 


### PR DESCRIPTION
This can be done through the `DCOS_TASK_ESCAPE_SEQUENCE` env var.

The value follows the same semantics as Docker, see:

https://docs.docker.com/engine/reference/commandline/attach/#override-the-detach-sequence

As a follow-up step in dcos/dcos-cli, we will introduce a new
`task.escape_sequence` config option. The plugin invocation system
will also be updated to pass configuration keys for subcommands as
env variables.

https://jira.mesosphere.com/browse/DCOS-57542