### PR TITLE
Add `SCARCE` column to `marathon debug details` command output

### DIFF
--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -1233,7 +1233,8 @@ class MarathonSubcommand(object):
                 emitter, queued_app,
                 tables.queued_app_details_table, json_)
         else:
-            raise DCOSException("Couldn't find app {} in Marathon queue".format(app_id))
+            raise DCOSException("Couldn't find app {} in Marathon queue"
+                                .format(app_id))
 
         return 0
 

--- a/python/lib/dcoscli/dcoscli/marathon/main.py
+++ b/python/lib/dcoscli/dcoscli/marathon/main.py
@@ -1233,7 +1233,7 @@ class MarathonSubcommand(object):
                 emitter, queued_app,
                 tables.queued_app_details_table, json_)
         else:
-            raise DCOSException("No apps found in Marathon queue")
+            raise DCOSException("Couldn't find app {} in Marathon queue".format(app_id))
 
         return 0
 

--- a/python/lib/dcoscli/dcoscli/tables.py
+++ b/python/lib/dcoscli/dcoscli/tables.py
@@ -832,7 +832,9 @@ def queued_app_details_table(queued_app):
         ('MEM', lambda entry: value_declined(entry, 'InsufficientMemory')),
         ('DISK', lambda entry: value_declined(entry, 'InsufficientDisk')),
         ('PORTS', lambda entry: value_declined(entry, 'UnfulfilledRole')),
-        ('SCARCE', lambda entry: value_declined(entry, 'DeclinedScarceResources')),
+        ('SCARCE', lambda entry:
+            value_declined(entry, 'DeclinedScarceResources')
+         ),
         ('RECEIVED', lambda entry:
             entry.get('timestamp', EMPTY_ENTRY)
          ),

--- a/python/lib/dcoscli/dcoscli/tables.py
+++ b/python/lib/dcoscli/dcoscli/tables.py
@@ -832,6 +832,7 @@ def queued_app_details_table(queued_app):
         ('MEM', lambda entry: value_declined(entry, 'InsufficientMemory')),
         ('DISK', lambda entry: value_declined(entry, 'InsufficientDisk')),
         ('PORTS', lambda entry: value_declined(entry, 'UnfulfilledRole')),
+        ('SCARCE', lambda entry: value_declined(entry, 'DeclinedScarceResources')),
         ('RECEIVED', lambda entry:
             entry.get('timestamp', EMPTY_ENTRY)
          ),


### PR DESCRIPTION
Summary:
Martathon added a new reason for declining an offer: `DeclinedScarceResources` signaling
that an offer was declined due to scarce resource (currently only GPUs are treated as scarce).

JIRA: COPS-5295