### PR TITLE
Allow diagnostics download to default to the latest created bundle

### DIFF
--- a/pkg/cmd/diagnostics/diagnostics_download.go
+++ b/pkg/cmd/diagnostics/diagnostics_download.go
@@ -17,12 +17,21 @@ func newDiagnosticsDownloadCommand(ctx api.Context) *cobra.Command {
 		// the <bundle-id> is used to indicate what the expected positional arg is in the help output
 		Use:   "download <bundle-id>",
 		Short: "Download diagnostics bundle",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := pluginutil.HTTPClient("")
 			client := diagnostics.NewClient(c)
 
-			id := args[0]
+			var id string
+			if len(args) == 0 {
+				bundle, err := latestBundle(client)
+				if err != nil {
+					return err
+				}
+				id = bundle.ID
+			} else {
+				id = args[0]
+			}
 
 			if outputPath == "" {
 				outputPath = fmt.Sprintf("%s.zip", id)

--- a/pkg/cmd/diagnostics/diagnostics_wait.go
+++ b/pkg/cmd/diagnostics/diagnostics_wait.go
@@ -1,7 +1,6 @@
 package diagnostics
 
 import (
-	"errors"
 	"time"
 
 	"github.com/dcos/dcos-cli/api"
@@ -55,31 +54,4 @@ func newDiagnosticsWaitCommand(ctx api.Context) *cobra.Command {
 	}
 
 	return cmd
-}
-
-func latestBundle(client *diagnostics.Client) (*diagnostics.Bundle, error) {
-	bundles, err := client.List()
-	if err != nil {
-		return nil, err
-	}
-	if len(bundles) == 0 {
-		return nil, errors.New("no bundles found")
-	}
-
-	// default time.Time is as far back we'll need to worry about anyway so serves as a good starting min
-	var max time.Time
-	var bundle diagnostics.Bundle
-
-	for _, b := range bundles {
-		if b.Type == diagnostics.Cluster && b.Started.After(max) {
-			max = b.Started
-			bundle = b
-		}
-	}
-
-	if max.Equal(time.Time{}) {
-		return nil, errors.New("no cluster bundles found")
-	}
-
-	return &bundle, nil
 }


### PR DESCRIPTION
This also moves `latestBundle` to `pkg/cmd/diagnostics/diagnostics.go` because it's now used in multiple commands.

Addresses: https://jira.mesosphere.com/browse/DCOS_OSS-5489