### PR TITLE
Refactor the rest of `dcos package repo...` into Go

### DIFF
--- a/pkg/cmd/pkg/package_repo_add.go
+++ b/pkg/cmd/pkg/package_repo_add.go
@@ -23,7 +23,11 @@ func newCmdPackageRepoAdd(ctx api.Context) *cobra.Command {
 				return err
 			}
 
-			_, err = c.PackageAddRepo(repoName, repoURL, index)
+			if cmd.Flags().Changed("index") {
+				_, err = c.PackageAddRepo(repoName, repoURL, &index)
+				return err
+			}
+			_, err = c.PackageAddRepo(repoName, repoURL, nil)
 			return err
 		},
 	}

--- a/pkg/cmd/pkg/package_repo_add.go
+++ b/pkg/cmd/pkg/package_repo_add.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos"
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +15,16 @@ func newCmdPackageRepoAdd(ctx api.Context) *cobra.Command {
 		Short: "Add a package repository to DC/OS",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return invokePythonCLI(ctx)
+			repoName := args[0]
+			repoURL := args[1]
+
+			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
+			if err != nil {
+				return err
+			}
+
+			_, err = c.PackageAddRepo(repoName, repoURL, index)
+			return err
 		},
 	}
 	cmd.Flags().IntVar(&index, "index", 0, "Numerical position in the package repository list. Package repositories are searched in descending order.")

--- a/pkg/cmd/pkg/package_repo_import.go
+++ b/pkg/cmd/pkg/package_repo_import.go
@@ -52,7 +52,7 @@ func newCmdPackageRepoImport(ctx api.Context) *cobra.Command {
 					continue
 				}
 
-				_, err = c.PackageAddRepo(repo.Name, repo.Uri, index)
+				_, err = c.PackageAddRepo(repo.Name, repo.Uri, &index)
 				if err != nil {
 					ctx.Logger().Warn(fmt.Sprintf("Error (%s) while adding repo '%s' (%s). Skipping.\n", err.Error(), repo.Name, repo.Uri))
 					continue

--- a/pkg/cmd/pkg/package_repo_list.go
+++ b/pkg/cmd/pkg/package_repo_list.go
@@ -2,9 +2,9 @@ package pkg
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/dcos/dcos-cli/api"
-	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-core-cli/pkg/cosmos"
 	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
@@ -39,14 +39,9 @@ func newCmdPackageRepoList(ctx api.Context) *cobra.Command {
 				return enc.Encode(repos)
 			}
 
-			tableHeader := []string{"NAME", "URI"}
-			table := cli.NewTable(ctx.Out(), tableHeader)
-
 			for _, r := range repos.Repositories {
-				fields := []string{r.Name, r.Uri}
-				table.Append(fields)
+				fmt.Fprintf(ctx.Out(), "%s: %s\n", r.Name, r.Uri)
 			}
-			table.Render()
 
 			return nil
 		},

--- a/pkg/cmd/pkg/package_repo_list.go
+++ b/pkg/cmd/pkg/package_repo_list.go
@@ -2,7 +2,6 @@ package pkg
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/cli"
@@ -14,8 +13,6 @@ import (
 const description = `Print the package repository sources
 
 Possible sources include a local file, HTTPS, and Git.`
-
-const noReposError = "There are currently no repos configured. Please use `dcos package repo add` to add a repo"
 
 func newCmdPackageRepoList(ctx api.Context) *cobra.Command {
 	var jsonOutput bool
@@ -40,11 +37,6 @@ func newCmdPackageRepoList(ctx api.Context) *cobra.Command {
 				enc := json.NewEncoder(ctx.Out())
 				enc.SetIndent("", "    ")
 				return enc.Encode(repos)
-			}
-
-			// TODO: this follows the python behavior but is this really an error?
-			if len(repos.Repositories) == 0 {
-				return errors.New(noReposError)
 			}
 
 			tableHeader := []string{"NAME", "URI"}

--- a/pkg/cmd/pkg/package_repo_list.go
+++ b/pkg/cmd/pkg/package_repo_list.go
@@ -1,13 +1,21 @@
 package pkg
 
 import (
+	"encoding/json"
+	"errors"
+
 	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos"
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
 const description = `Print the package repository sources
 
 Possible sources include a local file, HTTPS, and Git.`
+
+const noReposError = "There are currently no repos configured. Please use `dcos package repo add` to add a repo"
 
 func newCmdPackageRepoList(ctx api.Context) *cobra.Command {
 	var jsonOutput bool
@@ -18,7 +26,37 @@ func newCmdPackageRepoList(ctx api.Context) *cobra.Command {
 		Long:  description,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return invokePythonCLI(ctx)
+			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
+			if err != nil {
+				return err
+			}
+
+			repos, err := c.PackageListRepo()
+			if err != nil {
+				return err
+			}
+
+			if jsonOutput {
+				enc := json.NewEncoder(ctx.Out())
+				enc.SetIndent("", "    ")
+				return enc.Encode(repos)
+			}
+
+			// TODO: this follows the python behavior but is this really an error?
+			if len(repos.Repositories) == 0 {
+				return errors.New(noReposError)
+			}
+
+			tableHeader := []string{"NAME", "URI"}
+			table := cli.NewTable(ctx.Out(), tableHeader)
+
+			for _, r := range repos.Repositories {
+				fields := []string{r.Name, r.Uri}
+				table.Append(fields)
+			}
+			table.Render()
+
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print in json format")

--- a/pkg/cmd/pkg/package_repo_remove.go
+++ b/pkg/cmd/pkg/package_repo_remove.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos"
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +13,19 @@ func newCmdPackageRepoRemove(ctx api.Context) *cobra.Command {
 		Short: "Remove a package repository from DC/OS",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return invokePythonCLI(ctx)
+			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
+			if err != nil {
+				return err
+			}
+
+			for _, repoName := range args {
+				err = c.PackageDeleteRepo(repoName)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
 		},
 	}
 }

--- a/pkg/cosmos/client.go
+++ b/pkg/cosmos/client.go
@@ -172,14 +172,14 @@ func (c *Client) PackageSearch(query string) (*SearchResult, error) {
 }
 
 // PackageAddRepo adds a package repository.
-func (c *Client) PackageAddRepo(name string, uri string, index int) ([]dcos.CosmosPackageRepo, error) {
+func (c *Client) PackageAddRepo(name string, uri string, index *int) ([]dcos.CosmosPackageRepo, error) {
 	addRepoRequest := dcos.CosmosPackageAddRepoV1Request{
 		Name: name,
 		Uri:  uri,
 	}
 
-	if index > 0 {
-		index32 := int32(index)
+	if index != nil {
+		index32 := int32(*index)
 		addRepoRequest.Index = &index32
 	}
 

--- a/pkg/cosmos/client.go
+++ b/pkg/cosmos/client.go
@@ -3,6 +3,7 @@ package cosmos
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"sort"
@@ -186,7 +187,7 @@ func (c *Client) PackageAddRepo(name string, uri string, index int) ([]dcos.Cosm
 		CosmosPackageAddRepoV1Request: optional.NewInterface(addRepoRequest),
 	})
 	if err != nil {
-		return nil, err
+		return nil, cosmosErrUnwrap(err)
 	}
 	return desc.Repositories, nil
 }
@@ -198,14 +199,29 @@ func (c *Client) PackageDeleteRepo(name string) error {
 			Name: name,
 		}),
 	})
-	return err
+
+	return cosmosErrUnwrap(err)
 }
 
 // PackageListRepo returns a list of package repositories.
-func (c *Client) PackageListRepo() ([]dcos.CosmosPackageRepo, error) {
+func (c *Client) PackageListRepo() (*dcos.CosmosPackageListRepoV1Response, error) {
 	desc, _, err := c.cosmos.PackageRepositoryList(context.TODO(), nil)
 	if err != nil {
-		return nil, err
+		return nil, cosmosErrUnwrap(err)
 	}
-	return desc.Repositories, nil
+	return &desc, nil
+}
+
+func cosmosErrUnwrap(err error) error {
+	switch err := err.(type) {
+	case dcos.GenericOpenAPIError:
+		if err.Model() != nil {
+			if e, ok := err.Model().(dcos.CosmosError); ok {
+				return fmt.Errorf(e.Message)
+			}
+		}
+		return err
+	default:
+		return err
+	}
 }

--- a/python/lib/dcoscli/tests/data/package/json/test_repo_list.json
+++ b/python/lib/dcoscli/tests/data/package/json/test_repo_list.json
@@ -1,16 +1,16 @@
 {
-  "repositories": [
-    {
-      "name": "Universe",
-      "uri": "https://universe.mesosphere.com/repo"
-    },
-    {
-      "name": "Bootstrap Registry",
-      "uri": "https://registry.component.thisdcos.directory/repo"
-    },
-    {
-      "name": "helloworld-universe",
-      "uri": "http://helloworld-universe.marathon.mesos:8086/repo"
-    }
-  ]
+    "repositories": [
+        {
+            "name": "Universe",
+            "uri": "https://universe.mesosphere.com/repo"
+        },  
+        {
+            "name": "Bootstrap Registry",
+            "uri": "https://registry.component.thisdcos.directory/repo"
+        },  
+        {
+            "name": "helloworld-universe",
+            "uri": "http://helloworld-universe.marathon.mesos:8086/repo"
+        }
+    ]
 }

--- a/python/lib/dcoscli/tests/data/package/json/test_repo_list.json
+++ b/python/lib/dcoscli/tests/data/package/json/test_repo_list.json
@@ -3,11 +3,11 @@
         {
             "name": "Universe",
             "uri": "https://universe.mesosphere.com/repo"
-        },  
+        },
         {
             "name": "Bootstrap Registry",
             "uri": "https://registry.component.thisdcos.directory/repo"
-        },  
+        },
         {
             "name": "helloworld-universe",
             "uri": "http://helloworld-universe.marathon.mesos:8086/repo"

--- a/python/lib/dcoscli/tests/integrations/test_package.py
+++ b/python/lib/dcoscli/tests/integrations/test_package.py
@@ -503,6 +503,7 @@ def test_uninstall_cli():
     _uninstall_helloworld()
 
 
+@pytest.mark.skip(reason="Cosmos issue, see https://jira.mesosphere.com/browse/DCOS_OSS-5529")
 def test_uninstall_multiple_apps():
     stdout = (
         b'By Deploying, you agree to the Terms '

--- a/python/lib/dcoscli/tests/integrations/test_package.py
+++ b/python/lib/dcoscli/tests/integrations/test_package.py
@@ -105,11 +105,9 @@ def test_repo_remove_multi_and_empty():
 
     returncode, stdout, stderr = exec_command(
         ['dcos', 'package', 'repo', 'list'])
-    stderr_msg = (b"There are currently no repos configured. "
-                  b"Please use `dcos package repo add` to add a repo\n")
-    assert returncode == 1
+    assert returncode == 0
     assert stdout == b''
-    assert stderr == stderr_msg
+    assert stderr == b''
 
     # Add back test repos
     for name, url in UNIVERSE_TEST_REPOS.items():
@@ -503,7 +501,8 @@ def test_uninstall_cli():
     _uninstall_helloworld()
 
 
-@pytest.mark.skip(reason="Cosmos issue, see https://jira.mesosphere.com/browse/DCOS_OSS-5529")
+@pytest.mark.skip(reason=("Cosmos issue, see "
+                          "https://jira.mesosphere.com/browse/DCOS_OSS-5529"))
 def test_uninstall_multiple_apps():
     stdout = (
         b'By Deploying, you agree to the Terms '

--- a/python/lib/dcoscli/tests/integrations/test_sanity.py
+++ b/python/lib/dcoscli/tests/integrations/test_sanity.py
@@ -73,7 +73,7 @@ def test_add_pod():
 
 def test_repo_list():
     repo_list = file_json(
-        'tests/data/package/json/test_repo_list.json')
+        'tests/data/package/json/test_repo_list.json', indent=4)
     assert_command(
         ['dcos', 'package', 'repo', 'list', '--json'], stdout=repo_list)
 


### PR DESCRIPTION
This changes `add`, `list`, and `remove` to be done in Go instead of calling out to the python CLI.
Addresses: https://jira.mesosphere.com/browse/DCOS_OSS-4776