### PR TITLE
Fix Docker perm issue on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,10 @@ ifdef NO_DOCKER
   endef
 else
   define inDocker
+    # Run as the current user and make sure the $HOME folder is writable.
     docker run \
-		  -e GOFLAGS -e GO111MODULE \
+      -e GOFLAGS -e GO111MODULE -e HOME=/tmp \
+      -u $(shell id -u):$(shell id -g) \
       -v $(CURRENT_DIR):$(PKG_DIR) \
       -w $(PKG_DIR) \
       --rm \


### PR DESCRIPTION
When running `make` using Docker (`NO_DOCKER` is not exported), the
`make plugin` command then fails on Linux because of a permission issue.
The binary is owned by root thus the plugin ZIP cannot be created.

This changes the Docker command to run as the current user, it also sets
the HOME directory to `/tmp` as `/root` wouldn't be writable but is
still needed for Go cache files.