### PR TITLE
Build with the latest Go 1.11 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.11.0
+FROM golang:1.11
 
 RUN go get -u golang.org/x/lint/golint


### PR DESCRIPTION
Go 1.11.0 is very old and lots of bugs have been fixed until 1.11.13.

https://jira.mesosphere.com/browse/COPS-5314