### PR TITLE
Revert "Refactor the rest of `dcos package repo...` into Go (#346)"

### DIFF
--- a/pkg/cmd/pkg/package_repo_add.go
+++ b/pkg/cmd/pkg/package_repo_add.go
@@ -2,8 +2,6 @@ package pkg
 
 import (
 	"github.com/dcos/dcos-cli/api"
-	"github.com/dcos/dcos-core-cli/pkg/cosmos"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -15,20 +13,7 @@ func newCmdPackageRepoAdd(ctx api.Context) *cobra.Command {
 		Short: "Add a package repository to DC/OS",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			repoName := args[0]
-			repoURL := args[1]
-
-			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
-			if err != nil {
-				return err
-			}
-
-			if cmd.Flags().Changed("index") {
-				_, err = c.PackageAddRepo(repoName, repoURL, &index)
-				return err
-			}
-			_, err = c.PackageAddRepo(repoName, repoURL, nil)
-			return err
+			return invokePythonCLI(ctx)
 		},
 	}
 	cmd.Flags().IntVar(&index, "index", 0, "Numerical position in the package repository list. Package repositories are searched in descending order.")

--- a/pkg/cmd/pkg/package_repo_import.go
+++ b/pkg/cmd/pkg/package_repo_import.go
@@ -52,7 +52,7 @@ func newCmdPackageRepoImport(ctx api.Context) *cobra.Command {
 					continue
 				}
 
-				_, err = c.PackageAddRepo(repo.Name, repo.Uri, &index)
+				_, err = c.PackageAddRepo(repo.Name, repo.Uri, index)
 				if err != nil {
 					ctx.Logger().Warn(fmt.Sprintf("Error (%s) while adding repo '%s' (%s). Skipping.\n", err.Error(), repo.Name, repo.Uri))
 					continue

--- a/pkg/cmd/pkg/package_repo_list.go
+++ b/pkg/cmd/pkg/package_repo_list.go
@@ -1,12 +1,7 @@
 package pkg
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/dcos/dcos-cli/api"
-	"github.com/dcos/dcos-core-cli/pkg/cosmos"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -23,27 +18,7 @@ func newCmdPackageRepoList(ctx api.Context) *cobra.Command {
 		Long:  description,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
-			if err != nil {
-				return err
-			}
-
-			repos, err := c.PackageListRepo()
-			if err != nil {
-				return err
-			}
-
-			if jsonOutput {
-				enc := json.NewEncoder(ctx.Out())
-				enc.SetIndent("", "    ")
-				return enc.Encode(repos)
-			}
-
-			for _, r := range repos.Repositories {
-				fmt.Fprintf(ctx.Out(), "%s: %s\n", r.Name, r.Uri)
-			}
-
-			return nil
+			return invokePythonCLI(ctx)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print in json format")

--- a/pkg/cmd/pkg/package_repo_remove.go
+++ b/pkg/cmd/pkg/package_repo_remove.go
@@ -2,8 +2,6 @@ package pkg
 
 import (
 	"github.com/dcos/dcos-cli/api"
-	"github.com/dcos/dcos-core-cli/pkg/cosmos"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -13,19 +11,7 @@ func newCmdPackageRepoRemove(ctx api.Context) *cobra.Command {
 		Short: "Remove a package repository from DC/OS",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
-			if err != nil {
-				return err
-			}
-
-			for _, repoName := range args {
-				err = c.PackageDeleteRepo(repoName)
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
+			return invokePythonCLI(ctx)
 		},
 	}
 }

--- a/python/lib/dcoscli/tests/data/package/json/test_repo_list.json
+++ b/python/lib/dcoscli/tests/data/package/json/test_repo_list.json
@@ -1,16 +1,16 @@
 {
-    "repositories": [
-        {
-            "name": "Universe",
-            "uri": "https://universe.mesosphere.com/repo"
-        },
-        {
-            "name": "Bootstrap Registry",
-            "uri": "https://registry.component.thisdcos.directory/repo"
-        },
-        {
-            "name": "helloworld-universe",
-            "uri": "http://helloworld-universe.marathon.mesos:8086/repo"
-        }
-    ]
+  "repositories": [
+    {
+      "name": "Universe",
+      "uri": "https://universe.mesosphere.com/repo"
+    },
+    {
+      "name": "Bootstrap Registry",
+      "uri": "https://registry.component.thisdcos.directory/repo"
+    },
+    {
+      "name": "helloworld-universe",
+      "uri": "http://helloworld-universe.marathon.mesos:8086/repo"
+    }
+  ]
 }

--- a/python/lib/dcoscli/tests/integrations/test_package.py
+++ b/python/lib/dcoscli/tests/integrations/test_package.py
@@ -105,9 +105,11 @@ def test_repo_remove_multi_and_empty():
 
     returncode, stdout, stderr = exec_command(
         ['dcos', 'package', 'repo', 'list'])
-    assert returncode == 0
+    stderr_msg = (b"There are currently no repos configured. "
+                  b"Please use `dcos package repo add` to add a repo\n")
+    assert returncode == 1
     assert stdout == b''
-    assert stderr == b''
+    assert stderr == stderr_msg
 
     # Add back test repos
     for name, url in UNIVERSE_TEST_REPOS.items():
@@ -501,8 +503,6 @@ def test_uninstall_cli():
     _uninstall_helloworld()
 
 
-@pytest.mark.skip(reason=("Cosmos issue, see "
-                          "https://jira.mesosphere.com/browse/DCOS_OSS-5529"))
 def test_uninstall_multiple_apps():
     stdout = (
         b'By Deploying, you agree to the Terms '

--- a/python/lib/dcoscli/tests/integrations/test_sanity.py
+++ b/python/lib/dcoscli/tests/integrations/test_sanity.py
@@ -73,7 +73,7 @@ def test_add_pod():
 
 def test_repo_list():
     repo_list = file_json(
-        'tests/data/package/json/test_repo_list.json', indent=4)
+        'tests/data/package/json/test_repo_list.json')
     assert_command(
         ['dcos', 'package', 'repo', 'list', '--json'], stdout=repo_list)
 


### PR DESCRIPTION
This reverts commit 0c721636d8722a31c5182e25c2ccf7806863cedf.

We had to mute a test while refactoring the command, this is still
tracked in https://jira.mesosphere.com/browse/DCOS_OSS-5529 and we
didn't identify yet what is the cause of it. It might be a regression
with our Go code.

As DC/OS 2.0 now only receives fixes, we should continue the Go
refactoring on the 2.1 branch.