### PR TITLE
[2.0] Add missing fields in job definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.0-patch.x
+
+* Fixes
+
+  * Support more fields in job JSON definition.
+
 ## 2.0-patch.2
 
 This release reverts https://github.com/dcos/dcos-core-cli/pull/354.

--- a/pkg/cmd/job/job_test.go
+++ b/pkg/cmd/job/job_test.go
@@ -10,18 +10,19 @@ import (
 func TestParseJSONJob(t *testing.T) {
 	reader := strings.NewReader(`
 {
-        "id": "sleepy-test-docker",
-        "description": "A job that sleeps",
-        "run": {
-                "cmd": "echo 'Snoozing ...'; sleep 10; echo 'Awake now!'",
-                "cpus": 2,
-                "mem": 32,
-                "disk": 10,
-                "docker": {
-                        "image": "alpine:latest",
-                        "forcePullImage": true
-                }
-        }
+	"id": "sleepy-test-docker",
+	"description": "A job that sleeps",
+	"run": {
+		"cmd": "echo 'Snoozing ...'; sleep 10; echo 'Awake now!'",
+		"cpus": 2,
+		"mem": 32,
+		"disk": 10,
+		"docker": {
+			"image": "alpine:latest",
+			"forcePullImage": true,
+			"privileged": true
+		}
+	}
 }`)
 
 	job, err := parseJSONJob(reader)
@@ -39,4 +40,5 @@ func TestParseJSONJob(t *testing.T) {
 	// Docker
 	require.Equal(t, "alpine:latest", job.Run.Docker.Image)
 	require.True(t, job.Run.Docker.ForcePullImage)
+	require.True(t, job.Run.Docker.Privileged)
 }

--- a/pkg/metronome/types.go
+++ b/pkg/metronome/types.go
@@ -14,22 +14,23 @@ type Job struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	// The run property of a Job represents the run configuration for that Job
 	Run struct {
-		Args           []string               `json:"args,omitempty"`
-		Artifacts      []artifact             `json:"artifacts,omitempty"`
-		Cmd            string                 `json:"cmd"`
-		Cpus           float32                `json:"cpus"`
-		Gpus           float32                `json:"gpus"`
-		Disk           int                    `json:"disk"`
-		Docker         *docker                `json:"docker,omitempty"`
-		Env            map[string]interface{} `json:"env,omitempty"`
-		MaxLaunchDelay int                    `json:"maxLaunchDelay,omitempty"`
-		Mem            int                    `json:"mem"`
-		Placement      *placement             `json:"placement,omitempty"`
-		Secrets        map[string]interface{} `json:"secrets,omitempty"`
-		UCR            *ucr                   `json:"ucr,omitempty"`
-		User           string                 `json:"user,omitempty"`
-		Restart        *restart               `json:"restart,omitempty"`
-		Volumes        []volume               `json:"volumes,omitempty"`
+		Args                       []string               `json:"args,omitempty"`
+		Artifacts                  []artifact             `json:"artifacts,omitempty"`
+		Cmd                        string                 `json:"cmd"`
+		Cpus                       float32                `json:"cpus"`
+		Gpus                       float32                `json:"gpus"`
+		Disk                       int                    `json:"disk"`
+		Docker                     *docker                `json:"docker,omitempty"`
+		Env                        map[string]interface{} `json:"env,omitempty"`
+		MaxLaunchDelay             int                    `json:"maxLaunchDelay,omitempty"`
+		Mem                        int                    `json:"mem"`
+		Placement                  *placement             `json:"placement,omitempty"`
+		Secrets                    map[string]interface{} `json:"secrets,omitempty"`
+		TaskKillGracePeriodSeconds float64                `json:"taskKillGracePeriodSeconds"`
+		UCR                        *ucr                   `json:"ucr,omitempty"`
+		User                       string                 `json:"user,omitempty"`
+		Restart                    *restart               `json:"restart,omitempty"`
+		Volumes                    []volume               `json:"volumes,omitempty"`
 	} `json:"run"`
 
 	// These properties depend on the embed parameters when querying the /v1/jobs endpoints.
@@ -49,10 +50,12 @@ type artifact struct {
 type docker struct {
 	Image          string `json:"image,omitempty"`
 	ForcePullImage bool   `json:"forcePullImage"`
+	Privileged     bool   `json:"privileged"`
 }
 
 type ucr struct {
-	Image map[string]interface{} `json:"image,omitempty"`
+	Image      map[string]interface{} `json:"image,omitempty"`
+	Privileged bool                   `json:"privileged"`
 }
 
 type placement struct {


### PR DESCRIPTION
The Go types were not in sync with the actual definition.

https://github.com/dcos/dcos-cli/issues/1494