### PR TITLE
Allow bundle creation for master/agents only

### DIFF
--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -10,6 +10,7 @@ import (
 )
 
 func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
+	opts := diagnostics.Options{}
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
@@ -17,7 +18,7 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			c := pluginutil.HTTPClient("")
 			client := diagnostics.NewClient(c)
 
-			id, err := client.Create()
+			id, err := client.Create(opts)
 			if err != nil {
 				return err
 			}
@@ -26,6 +27,8 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().BoolVar(&opts.Masters, "masters", true, "Enable bundle collection on masters")
+	cmd.Flags().BoolVar(&opts.Agents, "agents", true, "Enable bundle collection on agents")
 
 	return cmd
 }

--- a/pkg/diagnostics/v2/client.go
+++ b/pkg/diagnostics/v2/client.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,6 +23,12 @@ type Bundle struct {
 	Started time.Time `json:"started_at,omitempty"`
 	Stopped time.Time `json:"stopped_at,omitempty"`
 	Errors  []string  `json:"errors,omitempty"`
+}
+
+// Options represents a bundle creation options passed to the diagnostics Create API
+type Options struct {
+	Masters bool `json:"masters"`
+	Agents  bool `json:"agents"`
 }
 
 // IsFinished returns if the bundle has a status that indicating that it is finished.
@@ -86,8 +93,15 @@ func (c *Client) Download(id string, dst io.Writer) error {
 }
 
 // Create creates a new cluster bundle and returns its ID.
-func (c *Client) Create() (string, error) {
-	req, err := c.http.NewRequest("PUT", fmt.Sprintf("%s/%s", baseURL, uuid.NewV4().String()), nil)
+func (c *Client) Create(options Options) (string, error) {
+	opts, err := json.Marshal(options)
+	if err != nil {
+		return "", fmt.Errorf("could not marashal options: %s", opts)
+	}
+	req, err := c.http.NewRequest("PUT",
+		fmt.Sprintf("%s/%s", baseURL, uuid.NewV4().String()),
+		bytes.NewBuffer(opts),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/diagnostics/v2/client_test.go
+++ b/pkg/diagnostics/v2/client_test.go
@@ -198,7 +198,7 @@ func TestCreateHappyPath(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(pluginutil.HTTPClient(ts.URL))
-	id, err := c.Create()
+	id, err := c.Create(Options{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, newID.String(), id)
@@ -211,7 +211,7 @@ func TestCreateServerError(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(pluginutil.HTTPClient(ts.URL))
-	id, err := c.Create()
+	id, err := c.Create(Options{})
 	assert.Error(t, err)
 	assert.Empty(t, id)
 


### PR DESCRIPTION
Previous API allow fine grained control over which nodes data should be included in the bundle. This change adds the most used function to create master only bundle with `dcos diagnostics create --agents=false`.

Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5547