### PR TITLE
Allow bundle creation only for nodes or masters

### DIFF
--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -10,6 +10,7 @@ import (
 )
 
 func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
+	opts := diagnostics.Options{}
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
@@ -17,7 +18,7 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			c := pluginutil.HTTPClient("")
 			client := diagnostics.NewClient(c)
 
-			id, err := client.Create()
+			id, err := client.Create(opts)
 			if err != nil {
 				return err
 			}
@@ -26,6 +27,8 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().BoolVar(&opts.Masters, "masters", true, "Enable bundle collection on masters")
+	cmd.Flags().BoolVar(&opts.Agents, "agents", true, "Enable bundle collection on agents")
 
 	return cmd
 }

--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -10,14 +10,23 @@ import (
 )
 
 func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
-	opts := diagnostics.Options{}
+	var masters bool
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := pluginutil.HTTPClient("")
 			client := diagnostics.NewClient(c)
-
+			opts := diagnostics.Options{
+				Masters: true,
+				Agents:  true,
+			}
+			if masters {
+				opts = diagnostics.Options{
+					Masters: true,
+					Agents:  false,
+				}
+			}
 			id, err := client.Create(opts)
 			if err != nil {
 				return err
@@ -27,8 +36,7 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().BoolVar(&opts.Masters, "masters", true, "Enable bundle collection on masters")
-	cmd.Flags().BoolVar(&opts.Agents, "agents", true, "Enable bundle collection on agents")
+	cmd.Flags().BoolVar(&masters, "masters", true, "Collect data from masters only")
 
 	return cmd
 }

--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
-	var masters bool
+	var mastersOnly bool
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
@@ -19,13 +19,7 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			client := diagnostics.NewClient(c)
 			opts := diagnostics.Options{
 				Masters: true,
-				Agents:  true,
-			}
-			if masters {
-				opts = diagnostics.Options{
-					Masters: true,
-					Agents:  false,
-				}
+				Agents:  !mastersOnly,
 			}
 			id, err := client.Create(opts)
 			if err != nil {
@@ -36,7 +30,7 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().BoolVar(&masters, "masters", true, "Collect data from masters only")
+	cmd.Flags().BoolVar(&mastersOnly, "masters", false, "Collect data from masters only")
 
 	return cmd
 }

--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -19,7 +19,7 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			client := diagnostics.NewClient(c)
 			opts := diagnostics.Options{
 				Masters: masters || !masters && !agents,
-				Agents: agents || !masters && !agents,
+				Agents:  agents || !masters && !agents,
 			}
 			id, err := client.Create(opts)
 			if err != nil {

--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -10,7 +10,7 @@ import (
 )
 
 func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
-	var mastersOnly bool
+	var agents, masters bool
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
@@ -18,8 +18,8 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			c := pluginutil.HTTPClient("")
 			client := diagnostics.NewClient(c)
 			opts := diagnostics.Options{
-				Masters: true,
-				Agents:  !mastersOnly,
+				Masters: masters || !masters && !agents,
+				Agents: agents || !masters && !agents,
 			}
 			id, err := client.Create(opts)
 			if err != nil {
@@ -30,7 +30,8 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().BoolVar(&mastersOnly, "masters", false, "Collect data from masters only")
+	cmd.Flags().BoolVar(&masters, "masters", false, "Collect data from masters")
+	cmd.Flags().BoolVar(&agents, "agents", false, "Collect data from agents")
 
 	return cmd
 }

--- a/pkg/cmd/job/job_test.go
+++ b/pkg/cmd/job/job_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseJSONJob(t *testing.T) {

--- a/pkg/cmd/pkg/package_describe_test.go
+++ b/pkg/cmd/pkg/package_describe_test.go
@@ -3,12 +3,13 @@ package pkg
 import (
 	"bytes"
 	"fmt"
-	"github.com/dcos/client-go/dcos"
-	"github.com/dcos/dcos-core-cli/pkg/cosmos"
-	"github.com/dcos/dcos-core-cli/pkg/cosmos/mocks"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/dcos/client-go/dcos"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos/mocks"
 
 	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/spf13/afero"
@@ -35,8 +36,7 @@ func TesPkgDescribeShouldProxyCommandsToCosmos(t *testing.T) {
 			ReleaseVersion:   9223372036854775807,
 			Version:          "0.0.2",
 			Marathon: dcos.CosmosPackageMarathon{
-				V2AppMustacheTemplate:
-				"ewogICAgImlkIjogInt7aGVsbG93b3JsZC5pZH19IiwKICAgICJjbWQiOiAiZWNobyAnSGVsbG8gV29ybGQnIgp9",
+				V2AppMustacheTemplate: "ewogICAgImlkIjogInt7aGVsbG93b3JsZC5pZH19IiwKICAgICJjbWQiOiAiZWNobyAnSGVsbG8gV29ybGQnIgp9",
 			},
 			Config: map[string]interface{}{
 				"foo": "bar",

--- a/pkg/diagnostics/v2/client.go
+++ b/pkg/diagnostics/v2/client.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,6 +23,12 @@ type Bundle struct {
 	Started time.Time `json:"started_at,omitempty"`
 	Stopped time.Time `json:"stopped_at,omitempty"`
 	Errors  []string  `json:"errors,omitempty"`
+}
+
+// Options represents a bundle creation options passed to the diagnostics Create API
+type Options struct {
+	Masters bool `json:"masters"`
+	Agents  bool `json:"agents"`
 }
 
 // IsFinished returns if the bundle has a status that indicating that it is finished.
@@ -86,8 +93,15 @@ func (c *Client) Download(id string, dst io.Writer) error {
 }
 
 // Create creates a new cluster bundle and returns its ID.
-func (c *Client) Create() (string, error) {
-	req, err := c.http.NewRequest("PUT", fmt.Sprintf("%s/%s", baseURL, uuid.NewV4().String()), nil)
+func (c *Client) Create(options Options) (string, error) {
+	opts, err := json.Marshal(options)
+	if err != nil {
+		return "", fmt.Errorf("could not marashal options: %s", opts)
+	}
+	req, err := c.http.NewRequest("PUT",
+		fmt.Sprintf("%s/%s", baseURL, uuid.NewV4().String()),
+		bytes.NewBuffer(opts),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/diagnostics/v2/client.go
+++ b/pkg/diagnostics/v2/client.go
@@ -96,7 +96,7 @@ func (c *Client) Download(id string, dst io.Writer) error {
 func (c *Client) Create(options Options) (string, error) {
 	opts, err := json.Marshal(options)
 	if err != nil {
-		return "", fmt.Errorf("could not marashal options: %s", opts)
+		return "", fmt.Errorf("could not marshal options: %s", opts)
 	}
 	req, err := c.http.NewRequest("PUT",
 		fmt.Sprintf("%s/%s", baseURL, uuid.NewV4().String()),

--- a/pkg/diagnostics/v2/client_test.go
+++ b/pkg/diagnostics/v2/client_test.go
@@ -210,8 +210,8 @@ func TestCreateHappyPath(t *testing.T) {
 	}{
 		{expected: `{"masters":false,"agents":false}`, given: Options{}},
 		{expected: `{"masters":true,"agents":false}`, given: Options{Masters: true}},
-		{expected: `{"masters":false,"agents":true}`, given: Options{Agents:true}},
-		{expected: `{"masters":true,"agents":true}`, given: Options{Masters: true, Agents:true}},
+		{expected: `{"masters":false,"agents":true}`, given: Options{Agents: true}},
+		{expected: `{"masters":true,"agents":true}`, given: Options{Masters: true, Agents: true}},
 	} {
 		t.Run(tc.expected, func(t *testing.T) {
 			ts := httptest.NewServer(handler(t, tc.expected))

--- a/pkg/diagnostics/v2/client_test.go
+++ b/pkg/diagnostics/v2/client_test.go
@@ -198,7 +198,7 @@ func TestCreateHappyPath(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(pluginutil.HTTPClient(ts.URL))
-	id, err := c.Create()
+	id, err := c.Create(Options{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, newID.String(), id)
@@ -211,7 +211,7 @@ func TestCreateServerError(t *testing.T) {
 	defer ts.Close()
 
 	c := NewClient(pluginutil.HTTPClient(ts.URL))
-	id, err := c.Create()
+	id, err := c.Create(Options{})
 	assert.Error(t, err)
 	assert.Empty(t, id)
 

--- a/pkg/diagnostics/v2/client_test.go
+++ b/pkg/diagnostics/v2/client_test.go
@@ -185,23 +185,43 @@ func TestDeleteWithDeletedBundle(t *testing.T) {
 
 func TestCreateHappyPath(t *testing.T) {
 	var newID uuid.UUID
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		re := regexp.MustCompile("^/system/health/v1/diagnostics/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$")
-		urlMatch := re.FindStringSubmatch(r.URL.Path)
-		idMatch := urlMatch[1]
-		var err error
-		newID, err = uuid.FromString(idMatch)
-		assert.NoError(t, err)
-		assert.Equal(t, "PUT", r.Method)
-		fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","status":"Started","started_at":"2019-08-19T08:07:24.404239211Z","stopped_at":"0001-01-01T00:00:00Z"}`, newID))
-	}))
-	defer ts.Close()
+	re := regexp.MustCompile("^/system/health/v1/diagnostics/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$")
+	handler := func(t *testing.T, expectedBody string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			urlMatch := re.FindStringSubmatch(r.URL.Path)
+			idMatch := urlMatch[1]
+			var err error
+			newID, err = uuid.FromString(idMatch)
+			body, err := ioutil.ReadAll(r.Body)
 
-	c := NewClient(pluginutil.HTTPClient(ts.URL))
-	id, err := c.Create(Options{})
-	assert.NoError(t, err)
+			assert.NoError(t, err)
+			assert.Equal(t, "PUT", r.Method)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedBody, string(body))
 
-	assert.Equal(t, newID.String(), id)
+			_, err = fmt.Fprint(w, fmt.Sprintf(`{"id":"%s","status":"Started","started_at":"2019-08-19T08:07:24.404239211Z","stopped_at":"0001-01-01T00:00:00Z"}`, newID))
+			assert.NoError(t, err)
+		})
+	}
+
+	for _, tc := range []struct {
+		expected string
+		given    Options
+	}{
+		{expected: `{"masters":false,"agents":false}`, given: Options{}},
+		{expected: `{"masters":true,"agents":false}`, given: Options{Masters: true}},
+		{expected: `{"masters":false,"agents":true}`, given: Options{Agents:true}},
+		{expected: `{"masters":true,"agents":true}`, given: Options{Masters: true, Agents:true}},
+	} {
+		t.Run(tc.expected, func(t *testing.T) {
+			ts := httptest.NewServer(handler(t, tc.expected))
+			defer ts.Close()
+			c := NewClient(pluginutil.HTTPClient(ts.URL))
+			id, err := c.Create(tc.given)
+			assert.NoError(t, err)
+			assert.Equal(t, newID.String(), id)
+		})
+	}
 }
 
 func TestCreateServerError(t *testing.T) {

--- a/pkg/sshclient/client.go
+++ b/pkg/sshclient/client.go
@@ -106,7 +106,7 @@ func (c *Client) Run(command []string) error {
 	}
 
 	args := append(c.args, command...)
-	cmd := exec.Command(c.opts.BinaryPath, args...)
+	cmd := exec.Command(c.opts.BinaryPath, args...) // nolint: gosec
 	c.logger.Debugf("Running: %v\n", cmd.Args)
 
 	cmd.Stdin = c.opts.Input


### PR DESCRIPTION
Previous API allow fine grained control over which nodes data should be
included in the bundle. This change adds the most used function to
create master only bundle with `dcos diagnostics create --masters`.

Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5547