### PR TITLE
Allow bundle creation only for nodes or masters

### DIFF
--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -10,14 +10,18 @@ import (
 )
 
 func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
+	var agents, masters bool
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := pluginutil.HTTPClient("")
 			client := diagnostics.NewClient(c)
-
-			id, err := client.Create()
+			opts := diagnostics.Options{
+				Masters: masters || !masters && !agents,
+				Agents:  agents || !masters && !agents,
+			}
+			id, err := client.Create(opts)
 			if err != nil {
 				return err
 			}
@@ -26,6 +30,8 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().BoolVar(&masters, "masters", false, "Collect data from masters")
+	cmd.Flags().BoolVar(&agents, "agents", false, "Collect data from agents")
 
 	return cmd
 }

--- a/pkg/sshclient/client.go
+++ b/pkg/sshclient/client.go
@@ -106,7 +106,7 @@ func (c *Client) Run(command []string) error {
 	}
 
 	args := append(c.args, command...)
-	cmd := exec.Command(c.opts.BinaryPath, args...)
+	cmd := exec.Command(c.opts.BinaryPath, args...) // nolint: gosec
 	c.logger.Debugf("Running: %v\n", cmd.Args)
 
 	cmd.Stdin = c.opts.Input


### PR DESCRIPTION
# Backports: #371

* Allow bundle creation for master/agents only

    Previous API allow fine grained control over which nodes data should be included in the bundle. This change adds the most used function to create master only bundle with `dcos diagnostics create --agents=false`.

    Fixes: https://jira.mesosphere.com/browse/DCOS_OSS-5547

* Disable gosec on ssh command exec

    DC/OS Cli runs in user context and grabs arguments from user input. We need to trust that users knows what they are doing.
