### PR TITLE
Update dcos-e2e

### DIFF
--- a/python/lib/dcoscli/requirements.txt
+++ b/python/lib/dcoscli/requirements.txt
@@ -1,5 +1,5 @@
 sphinx>=1.3.1, <2.0
-tox>=2.2, <3.0
+tox>=2.2, <4.0
 wheel>=0.24.0, <1.0
 pytest>=2.9.1
 teamcity-messages>=1.20

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,9 +1,9 @@
---find-links git+https://github.com/dcos/dcos-e2e.git@2019.04.02.1#egg=dcos-e2e-2019.04.02.1
+--find-links git+https://github.com/dcos/dcos-e2e.git@2019.10.11.0#egg=dcos-e2e-2019.10.11.0
 --find-links git+https://github.com/dcos/dcos-launch.git@08bafb72fe7b0f2a8013d6ec9460e4aeb0e27406#egg=dcos-launch-0.1-dev
 --find-links git+https://github.com/dcos/dcos-test-utils.git@e8519d9c20c4f0859d90a0a1d7eeae5c3c52fe5d#egg=dcos-test-utils-0.1
 boto3==1.9.126
 click==6.7
-dcos-e2e==2019.04.02.1
+dcos-e2e==2019.10.11.0
 dcos_launch==0.1-dev
 dcos-test-utils==0.1
 requests==2.21.0


### PR DESCRIPTION
Nightly integration tests are now consistently failing.

Bumping dcos-e2e might fix the issue, which seems related to the recent
removal of dcos-history.

See https://github.com/dcos/dcos-test-utils/pull/101

https://jira.mesosphere.com/browse/DCOS_OSS-5600