### PR TITLE
Add CERTIFIED column to package list

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -34,7 +34,7 @@ enable = [
 line-length = 150
 
 [linters-settings.gocyclo]
-min-complexity = 40
+min-complexity = 30
 
 [linters-settings.govet]
 check-shadowing = false

--- a/pkg/cmd/pkg/package_list.go
+++ b/pkg/cmd/pkg/package_list.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -60,14 +61,14 @@ func newCmdPackageList(ctx api.Context) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.appID, "app-id", "", "The application ID")
 	cmd.Flags().BoolVar(&opts.cliOnly, "cli", false, "Command line only")
-	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "Print in json format")
+	cmd.Flags().BoolVar(&opts.jsonOutput, "json", false, "Print options json format")
 	return cmd
 }
 
 func listPackages(ctx api.Context, opts listOptions, c cosmos.Client) error {
 	packages, err := getPackagesInstalledLocally(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot read cluster data: %s", err)
 	}
 
 	if !opts.cliOnly {

--- a/pkg/cmd/pkg/package_list.go
+++ b/pkg/cmd/pkg/package_list.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -133,7 +134,7 @@ func newCmdPackageList(ctx api.Context) *cobra.Command {
 				return errors.New("there are currently no installed packages")
 			}
 
-			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "APP", "COMMAND", "DESCRIPTION"})
+			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "SELECTED", "APP", "COMMAND", "DESCRIPTION"})
 			for _, p := range list {
 				apps := "---"
 				if len(p.Apps) > 0 {
@@ -153,7 +154,7 @@ func newCmdPackageList(ctx api.Context) *cobra.Command {
 					description = description[0:66] + "..."
 				}
 
-				table.Append([]string{p.Name, p.Version, apps, command, description})
+				table.Append([]string{p.Name, p.Version, strconv.FormatBool(p.Selected), apps, command, description})
 			}
 			table.Render()
 

--- a/pkg/cmd/pkg/package_list.go
+++ b/pkg/cmd/pkg/package_list.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -167,9 +168,13 @@ func renderTable(ctx api.Context, list []cosmos.Package) {
 	table.Render()
 }
 
-func filterPackages(packages map[string]cosmos.Package, filter func(app string) bool) []cosmos.Package {
-	filteredList := make([]cosmos.Package, 0, len(packages))
-	for _, pkg := range packages {
+func filterPackages(pkgs map[string]cosmos.Package, filter func(app string) bool) []cosmos.Package {
+	filteredList := make([]cosmos.Package, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		if filter(pkg.Name) {
+			filteredList = append(filteredList, pkg)
+			continue
+		}
 		for _, app := range pkg.Apps {
 			if filter(app) {
 				filteredList = append(filteredList, pkg)
@@ -177,5 +182,13 @@ func filterPackages(packages map[string]cosmos.Package, filter func(app string) 
 			}
 		}
 	}
+
+	sort.Sort(packages(filteredList))
 	return filteredList
 }
+
+type packages []cosmos.Package
+
+func (p packages) Len() int           { return len(p) }
+func (p packages) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p packages) Less(i, j int) bool { return p[i].Name < p[j].Name }

--- a/pkg/cmd/pkg/package_list.go
+++ b/pkg/cmd/pkg/package_list.go
@@ -134,7 +134,7 @@ func newCmdPackageList(ctx api.Context) *cobra.Command {
 				return errors.New("there are currently no installed packages")
 			}
 
-			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "SELECTED", "APP", "COMMAND", "DESCRIPTION"})
+			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "CERTIFIED", "APP", "COMMAND", "DESCRIPTION"})
 			for _, p := range list {
 				apps := "---"
 				if len(p.Apps) > 0 {

--- a/pkg/cmd/pkg/package_list_test.go
+++ b/pkg/cmd/pkg/package_list_test.go
@@ -1,0 +1,173 @@
+package pkg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/dcos/client-go/dcos"
+	"github.com/dcos/dcos-cli/pkg/mock"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos/mocks"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListPackages(t *testing.T) {
+	var out bytes.Buffer
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	env.Out = &out
+	ctx := mock.NewContext(env)
+
+	client := &mocks.Client{}
+	packages := []cosmos.Package{
+		{
+			Name:        "package-1",
+			Apps:        []string{"a", "b", "c"},
+			Description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas cursus nec diam non fringilla. Duis consectetur sem vitae mi congue, et ultrices mauris mattis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse maximus bibendum neque, eget congue augue tristique sit amet. Duis porta molestie eros, et pellentesque tellus condimentum vel. Curabitur maximus velit condimentum justo bibendum, vel sollicitudin nibh varius. Duis euismod iaculis sem, ut lobortis ex venenatis nec. Proin at semper eros, et dignissim lorem. Vivamus id scelerisque risus. Nullam auctor et est ut aliquet. Donec sit amet sem velit. ",
+			Version:     "0.0.0.1",
+		},
+		{
+			Name:        "package-3",
+			Description: "Lorem ipsum dolor sit amet, \nconsectetur adipiscing elit. \nMaecenas cursus nec diam non fringilla. Duis consectetur sem vitae mi congue, et ultrices mauris mattis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse maximus bibendum neque, eget congue augue tristique sit amet. Duis porta molestie eros, et pellentesque tellus condimentum vel. Curabitur maximus velit condimentum justo bibendum, vel sollicitudin nibh varius. Duis euismod iaculis sem, ut lobortis ex venenatis nec. Proin at semper eros, et dignissim lorem. Vivamus id scelerisque risus. Nullam auctor et est ut aliquet. Donec sit amet sem velit. ",
+			Version:     "0.1",
+		},
+		{
+			Name:        "package-2",
+			Command:     &dcos.CosmosPackageCommand{Name: "xyz"},
+			Description: "XYZ",
+			Version:     "0.0.1",
+		},
+	}
+	client.On("PackageList").Return(packages, nil)
+
+	err := listPackages(ctx, listOptions{}, client)
+	assert.NoError(t, err)
+	assert.Equal(t, `    NAME     VERSION  CERTIFIED  APP  COMMAND                               DESCRIPTION                               
+  package-1  0.0.0.1  false      a    ---      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ...  
+                                 b                                                                                    
+                                 c                                                                                    
+  package-2  0.0.1    false      ---  xyz      XYZ                                                                    
+  package-3      0.1  false      ---  ---      Lorem ipsum dolor sit amet, ...                                        
+`, out.String())
+}
+
+func TestListPackagesFilterJson(t *testing.T) {
+	var out bytes.Buffer
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	env.Out = &out
+	ctx := mock.NewContext(env)
+
+	client := &mocks.Client{}
+	packages := []cosmos.Package{
+		{Name: "package-1", Apps: []string{"a", "b", "some-app"}, Description: "package-2", Version: "0.0.0.1"},
+		{Name: "package-2", Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Version: "0.0.1"},
+	}
+	client.On("PackageList").Return(packages, nil)
+
+	var testCases = []struct {
+		in  listOptions
+		out string
+	}{
+		{listOptions{jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{listOptions{query: "package-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{listOptions{query: "-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{listOptions{query: "package", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{listOptions{query: "a", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{listOptions{query: "some-app", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{listOptions{appID: "some-app", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{listOptions{appID: "a", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{listOptions{appID: "b", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{listOptions{appID: "package-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{listOptions{cliOnly: true, jsonOutput: true}, `[]`},
+		{listOptions{appID: "not found", jsonOutput: true}, `[]`},
+		{listOptions{query: "not found", jsonOutput: true}, `[]`},
+	}
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("%#v", tt.in), func(t *testing.T) {
+			var out bytes.Buffer
+			env.Out = &out
+
+			err := listPackages(ctx, tt.in, client)
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.out, out.String(), out.String())
+		})
+	}
+}
+
+func TestListErrorWhenNoPackageFound(t *testing.T) {
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	ctx := mock.NewContext(env)
+
+	client := &mocks.Client{}
+	packages := []cosmos.Package{
+		{Name: "package-1", Apps: []string{"a", "b", "some-app"}, Description: "package-2", Version: "0.0.0.1"},
+		{Name: "package-2", Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Version: "0.0.1"},
+	}
+	client.On("PackageList").Return(packages, nil)
+
+	var testCases = []listOptions{
+		{cliOnly: true},
+		{appID: "not found"},
+		{query: "not found"},
+	}
+	for _, options := range testCases {
+		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
+			var out bytes.Buffer
+			env.Out = &out
+
+			err := listPackages(ctx, options, client)
+			assert.EqualError(t, err, "cannot find packages matching the provided filter")
+			assert.Empty(t, out.Bytes())
+		})
+	}
+}
+
+func TestListErrorWhenNoPackageReturned(t *testing.T) {
+	var out bytes.Buffer
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	env.Out = &out
+	ctx := mock.NewContext(env)
+
+	client := &mocks.Client{}
+	client.On("PackageList").Return(nil, nil)
+
+	err := listPackages(ctx, listOptions{}, client)
+	assert.EqualError(t, err, "cannot find packages matching the provided filter")
+	assert.Empty(t, out.Bytes())
+}
+
+func TestListErrorWhenCosmosError(t *testing.T) {
+	var out bytes.Buffer
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	env.Out = &out
+	ctx := mock.NewContext(env)
+
+	client := &mocks.Client{}
+	client.On("PackageList").Return(nil, errors.New("cosmos error"))
+
+	err := listPackages(ctx, listOptions{}, client)
+	assert.EqualError(t, err, "cosmos error")
+	assert.Empty(t, out.Bytes())
+}

--- a/pkg/cmd/pkg/package_list_test.go
+++ b/pkg/cmd/pkg/package_list_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/dcos/dcos-cli/pkg/config"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/dcos/client-go/dcos"
@@ -14,15 +17,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const NoPlugins = "no_plugins"
+const MultipleCommands = "multiple_commands"
+
 func TestListPackages(t *testing.T) {
-	var out bytes.Buffer
-	env := mock.NewEnvironment()
-	env.Fs = afero.NewCopyOnWriteFs(
-		afero.NewReadOnlyFs(afero.NewOsFs()),
-		afero.NewMemMapFs(),
-	)
-	env.Out = &out
-	ctx := mock.NewContext(env)
+	out, ctx := setupCluster("multiple_commands")
 
 	client := &mocks.Client{}
 	packages := []cosmos.Package{
@@ -48,25 +47,18 @@ func TestListPackages(t *testing.T) {
 
 	err := listPackages(ctx, listOptions{}, client)
 	assert.NoError(t, err)
-	assert.Equal(t, `    NAME     VERSION  CERTIFIED  APP  COMMAND                               DESCRIPTION                               
-  package-1  0.0.0.1  false      a    ---      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ...  
-                                 b                                                                                    
-                                 c                                                                                    
-  package-2  0.0.1    false      ---  xyz      XYZ                                                                    
-  package-3      0.1  false      ---  ---      Lorem ipsum dolor sit amet, ...                                        
+	assert.Equal(t, `    NAME       VERSION     CERTIFIED    APP     COMMAND                               DESCRIPTION                               
+  cli-app    alpha         true       /cli-app  cli-app  Some CLI APP                                                           
+  package-1  0.0.0.1       false      a         ---      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas ...  
+                                      b                                                                                         
+                                      c                                                                                         
+  package-2  0.0.1         false      ---       xyz      XYZ                                                                    
+  package-3           0.1  false      ---       ---      Lorem ipsum dolor sit amet, ...                                        
+  pkg-cli    2.4.4-1.15.4  true       /pkg-cli  pkg-cli  Some CLI Package                                                       
 `, out.String())
 }
 
 func TestListPackagesFilterJson(t *testing.T) {
-	var out bytes.Buffer
-	env := mock.NewEnvironment()
-	env.Fs = afero.NewCopyOnWriteFs(
-		afero.NewReadOnlyFs(afero.NewOsFs()),
-		afero.NewMemMapFs(),
-	)
-	env.Out = &out
-	ctx := mock.NewContext(env)
-
 	client := &mocks.Client{}
 	packages := []cosmos.Package{
 		{Name: "package-1", Apps: []string{"a", "b", "some-app"}, Description: "package-2", Version: "0.0.0.1"},
@@ -74,30 +66,37 @@ func TestListPackagesFilterJson(t *testing.T) {
 	}
 	client.On("PackageList").Return(packages, nil)
 
+
 	var testCases = []struct {
-		in  listOptions
-		out string
+		cluster string
+		options listOptions
+		out     string
 	}{
-		{listOptions{jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
-		{listOptions{query: "package-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
-		{listOptions{query: "-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
-		{listOptions{query: "package", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
-		{listOptions{query: "a", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
-		{listOptions{query: "some-app", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
-		{listOptions{appID: "some-app", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
-		{listOptions{appID: "a", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
-		{listOptions{appID: "b", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
-		{listOptions{appID: "package-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
-		{listOptions{cliOnly: true, jsonOutput: true}, `[]`},
-		{listOptions{appID: "not found", jsonOutput: true}, `[]`},
-		{listOptions{query: "not found", jsonOutput: true}, `[]`},
+		{NoPlugins, listOptions{jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{NoPlugins, listOptions{query: "package-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{NoPlugins, listOptions{query: "-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{NoPlugins, listOptions{query: "package", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{NoPlugins, listOptions{query: "a", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"},{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{NoPlugins, listOptions{query: "some-app", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{NoPlugins, listOptions{appID: "some-app", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{NoPlugins, listOptions{appID: "a", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{NoPlugins, listOptions{appID: "b", jsonOutput: true}, `[{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{NoPlugins, listOptions{appID: "package-2", jsonOutput: true}, `[{"command":{"name":"xyz"},"description":"XYZ","framework":false,"name":"package-2","selected":false,"version":"0.0.1"}]`},
+		{NoPlugins, listOptions{cliOnly: true, jsonOutput: true}, `[]`},
+		{NoPlugins, listOptions{appID: "not found", jsonOutput: true}, `[]`},
+		{NoPlugins, listOptions{query: "not found", jsonOutput: true}, `[]`},
+		{MultipleCommands, listOptions{cliOnly: true, jsonOutput:true}, `[{"apps":["/cli-app"],"command":{"name":"cli-app"},"description":"Some CLI APP","framework":true,"name":"cli-app","selected":true,"version":"alpha"},{"apps":["/pkg-cli"],"command":{"name":"pkg-cli"},"description":"Some CLI Package","framework":true,"name":"pkg-cli","selected":true,"version":"2.4.4-1.15.4"}]`},
+		{MultipleCommands, listOptions{query: "cli", cliOnly:true, jsonOutput:true}, `[{"apps":["/cli-app"],"command":{"name":"cli-app"},"description":"Some CLI APP","framework":true,"name":"cli-app","selected":true,"version":"alpha"},{"apps":["/pkg-cli"],"command":{"name":"pkg-cli"},"description":"Some CLI Package","framework":true,"name":"pkg-cli","selected":true,"version":"2.4.4-1.15.4"}]`},
+		{MultipleCommands, listOptions{query: "app", jsonOutput:true}, `[{"apps":["/cli-app"],"command":{"name":"cli-app"},"description":"Some CLI APP","framework":true,"name":"cli-app","selected":true,"version":"alpha"},{"apps":["a","b","some-app"],"description":"package-2","framework":false,"name":"package-1","selected":false,"version":"0.0.0.1"}]`},
+		{MultipleCommands, listOptions{appID: "app", jsonOutput:true}, `[]`},
+		{MultipleCommands, listOptions{appID: "cli-app", jsonOutput:true}, `[{"apps":["/cli-app"],"command":{"name":"cli-app"},"description":"Some CLI APP","framework":true,"name":"cli-app","selected":true,"version":"alpha"}]`},
+		{MultipleCommands, listOptions{query: "package", cliOnly:true, jsonOutput:true}, `[]`},
 	}
 	for _, tt := range testCases {
-		t.Run(fmt.Sprintf("%#v", tt.in), func(t *testing.T) {
-			var out bytes.Buffer
-			env.Out = &out
+		t.Run(fmt.Sprintf("%s_%#v", tt.cluster, tt.options), func(t *testing.T) {
+			out, ctx := setupCluster(tt.cluster)
 
-			err := listPackages(ctx, tt.in, client)
+			err := listPackages(ctx, tt.options, client)
 			assert.NoError(t, err)
 			assert.JSONEq(t, tt.out, out.String(), out.String())
 		})
@@ -105,13 +104,6 @@ func TestListPackagesFilterJson(t *testing.T) {
 }
 
 func TestListErrorWhenNoPackageFound(t *testing.T) {
-	env := mock.NewEnvironment()
-	env.Fs = afero.NewCopyOnWriteFs(
-		afero.NewReadOnlyFs(afero.NewOsFs()),
-		afero.NewMemMapFs(),
-	)
-	ctx := mock.NewContext(env)
-
 	client := &mocks.Client{}
 	packages := []cosmos.Package{
 		{Name: "package-1", Apps: []string{"a", "b", "some-app"}, Description: "package-2", Version: "0.0.0.1"},
@@ -126,8 +118,7 @@ func TestListErrorWhenNoPackageFound(t *testing.T) {
 	}
 	for _, options := range testCases {
 		t.Run(fmt.Sprintf("%#v", options), func(t *testing.T) {
-			var out bytes.Buffer
-			env.Out = &out
+			out, ctx := setupCluster(NoPlugins)
 
 			err := listPackages(ctx, options, client)
 			assert.EqualError(t, err, "cannot find packages matching the provided filter")
@@ -137,14 +128,7 @@ func TestListErrorWhenNoPackageFound(t *testing.T) {
 }
 
 func TestListErrorWhenNoPackageReturned(t *testing.T) {
-	var out bytes.Buffer
-	env := mock.NewEnvironment()
-	env.Fs = afero.NewCopyOnWriteFs(
-		afero.NewReadOnlyFs(afero.NewOsFs()),
-		afero.NewMemMapFs(),
-	)
-	env.Out = &out
-	ctx := mock.NewContext(env)
+	out, ctx := setupCluster(NoPlugins)
 
 	client := &mocks.Client{}
 	client.On("PackageList").Return(nil, nil)
@@ -155,6 +139,25 @@ func TestListErrorWhenNoPackageReturned(t *testing.T) {
 }
 
 func TestListErrorWhenCosmosError(t *testing.T) {
+	out, ctx := setupCluster(NoPlugins)
+
+	client := &mocks.Client{}
+	client.On("PackageList").Return(nil, errors.New("cosmos error"))
+
+	err := listPackages(ctx, listOptions{}, client)
+	assert.EqualError(t, err, "cosmos error")
+	assert.Empty(t, out.Bytes())
+}
+
+func TestListErrorWhenClusterError(t *testing.T) {
+	out, ctx := setupCluster("invalid")
+
+	err := listPackages(ctx, listOptions{}, nil)
+	assert.EqualError(t, err, "cannot read cluster data: invalid character 'o' in literal null (expecting 'u')")
+	assert.Empty(t, out.Bytes())
+}
+
+func setupCluster(name string) (*bytes.Buffer, *mock.Context) {
 	var out bytes.Buffer
 	env := mock.NewEnvironment()
 	env.Fs = afero.NewCopyOnWriteFs(
@@ -163,11 +166,12 @@ func TestListErrorWhenCosmosError(t *testing.T) {
 	)
 	env.Out = &out
 	ctx := mock.NewContext(env)
-
-	client := &mocks.Client{}
-	client.On("PackageList").Return(nil, errors.New("cosmos error"))
-
-	err := listPackages(ctx, listOptions{}, client)
-	assert.EqualError(t, err, "cosmos error")
-	assert.Empty(t, out.Bytes())
+	wd, _ := os.Getwd()
+	clusterDir := filepath.Join(wd, "testdata", name)
+	conf := config.New(config.Opts{
+		Fs: env.Fs,
+	})
+	conf.SetPath(filepath.Join(clusterDir, "dcos.toml"))
+	ctx.SetCluster(config.NewCluster(conf))
+	return &out, ctx
 }

--- a/pkg/cmd/pkg/package_search.go
+++ b/pkg/cmd/pkg/package_search.go
@@ -45,7 +45,7 @@ func newCmdPackageSearch(ctx api.Context) *cobra.Command {
 				return errors.New("no packages found")
 			}
 
-			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "SELECTED", "FRAMEWORK", "DESCRIPTION"})
+			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "CERTIFIED", "FRAMEWORK", "DESCRIPTION"})
 			for _, cosmosPackage := range searchResult.Packages {
 				description := cosmosPackage.Description
 				if utf8.RuneCountInString(cosmosPackage.Description) >= 80 {

--- a/pkg/cmd/pkg/package_search.go
+++ b/pkg/cmd/pkg/package_search.go
@@ -21,49 +21,48 @@ func newCmdPackageSearch(ctx api.Context) *cobra.Command {
 		Short: "Search the package repository",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
-			if err != nil {
-				return err
-			}
-
 			query := ""
 			if len(args) == 1 {
 				query = args[0]
 			}
-			searchResult, err := c.PackageSearch(query)
+			c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))
 			if err != nil {
 				return err
 			}
-
-			if jsonOutput {
-				enc := json.NewEncoder(ctx.Out())
-				enc.SetIndent("", "    ")
-				return enc.Encode(searchResult)
-			}
-
-			if query != "" && len(searchResult.Packages) == 0 {
-				return errors.New("no packages found")
-			}
-
-			table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "CERTIFIED", "FRAMEWORK", "DESCRIPTION"})
-			for _, cosmosPackage := range searchResult.Packages {
-				description := cosmosPackage.Description
-				if utf8.RuneCountInString(cosmosPackage.Description) >= 80 {
-					description = description[0:76] + "..."
-				}
-				table.Append([]string{
-					cosmosPackage.Name,
-					cosmosPackage.CurrentVersion,
-					strconv.FormatBool(cosmosPackage.Selected),
-					strconv.FormatBool(cosmosPackage.Framework),
-					description,
-				})
-			}
-			table.Render()
-
-			return nil
+			return search(ctx, query, jsonOutput, c)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print in json format")
 	return cmd
+}
+
+func search(ctx api.Context, query string, jsonOutput bool, c cosmos.Client) error {
+	searchResult, err := c.PackageSearch(query)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(ctx.Out())
+		enc.SetIndent("", "    ")
+		return enc.Encode(searchResult)
+	}
+	if query != "" && len(searchResult.Packages) == 0 {
+		return errors.New("no packages found")
+	}
+	table := cli.NewTable(ctx.Out(), []string{"NAME", "VERSION", "CERTIFIED", "FRAMEWORK", "DESCRIPTION"})
+	for _, cosmosPackage := range searchResult.Packages {
+		description := cosmosPackage.Description
+		if utf8.RuneCountInString(cosmosPackage.Description) >= 80 {
+			description = description[0:76] + "..."
+		}
+		table.Append([]string{
+			cosmosPackage.Name,
+			cosmosPackage.CurrentVersion,
+			strconv.FormatBool(cosmosPackage.Selected),
+			strconv.FormatBool(cosmosPackage.Framework),
+			description,
+		})
+	}
+	table.Render()
+	return nil
 }

--- a/pkg/cmd/pkg/package_search_test.go
+++ b/pkg/cmd/pkg/package_search_test.go
@@ -1,0 +1,85 @@
+package pkg
+
+import (
+	"errors"
+	"github.com/dcos/client-go/dcos"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos"
+	"github.com/dcos/dcos-core-cli/pkg/cosmos/mocks"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSearchPackages(t *testing.T) {
+	out, ctx := setupCluster("multiple_commands")
+
+	client := &mocks.Client{}
+	searchResult := cosmos.SearchResult{Packages: []dcos.CosmosPackageSearchDetails{
+		{
+			Name:        "package-1",
+			Description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas cursus nec diam non fringilla. Duis consectetur sem vitae mi congue, et ultrices mauris mattis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse maximus bibendum neque, eget congue augue tristique sit amet. Duis porta molestie eros, et pellentesque tellus condimentum vel. Curabitur maximus velit condimentum justo bibendum, vel sollicitudin nibh varius. Duis euismod iaculis sem, ut lobortis ex venenatis nec. Proin at semper eros, et dignissim lorem. Vivamus id scelerisque risus. Nullam auctor et est ut aliquet. Donec sit amet sem velit. ",
+			CurrentVersion: "1",
+		},
+		{
+			Name:        "package-3",
+			Description: "Lorem ipsum dolor sit amet, \nconsectetur adipiscing elit. \nMaecenas cursus nec diam non fringilla. Duis consectetur sem vitae mi congue, et ultrices mauris mattis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Suspendisse maximus bibendum neque, eget congue augue tristique sit amet. Duis porta molestie eros, et pellentesque tellus condimentum vel. Curabitur maximus velit condimentum justo bibendum, vel sollicitudin nibh varius. Duis euismod iaculis sem, ut lobortis ex venenatis nec. Proin at semper eros, et dignissim lorem. Vivamus id scelerisque risus. Nullam auctor et est ut aliquet. Donec sit amet sem velit. ",
+			CurrentVersion: "3",
+			Framework: true,
+		},
+		{
+			Name:        "package-2",
+			Description: "XYZ",
+			CurrentVersion: "2",
+			Selected: true,
+		},
+	},
+	}
+	client.On("PackageSearch", "").Return(&searchResult, nil)
+
+	err := search(ctx, "", false, client)
+	assert.NoError(t, err)
+	assert.Equal(t, `    NAME     VERSION  CERTIFIED  FRAMEWORK                                    DESCRIPTION                                    
+  package-1        1  false      false      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas cursus nec...  
+  package-3        3  false      true       Lorem ipsum dolor sit amet,                                                      
+                                            consectetur adipiscing elit.                                                     
+                                            Maecenas cursus n...                                                             
+  package-2        2  true       false      XYZ                                                                              
+`, out.String())
+}
+
+func TestSearchPackagesNoPackagesFound(t *testing.T) {
+	client := &mocks.Client{}
+	client.On("PackageSearch", "").Return(&cosmos.SearchResult{}, nil)
+	client.On("PackageSearch", "some query").Return(&cosmos.SearchResult{}, nil)
+
+	out, ctx := setupCluster(NoPlugins)
+	err := search(ctx, "", false, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "  NAME  VERSION  CERTIFIED  FRAMEWORK  DESCRIPTION  \n", out.String())
+
+	out, ctx = setupCluster(NoPlugins)
+	err = search(ctx, "some query", false, client)
+	assert.EqualError(t, err, "no packages found")
+	assert.Empty(t, out.String())
+
+	out, ctx = setupCluster(NoPlugins)
+	err = search(ctx, "", true, client)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"packages": null}`, out.String())
+
+	out, ctx = setupCluster(NoPlugins)
+	err = search(ctx, "some query", true, client)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"packages": null}`, out.String())
+}
+
+func TestSearchPackagesCosmosError(t *testing.T) {
+	client := &mocks.Client{}
+	client.On("PackageSearch", "").Return(nil, errors.New("cosmos error"))
+
+	for _, jsonOutput := range []bool{true, false} {
+		out, ctx := setupCluster(NoPlugins)
+		err := search(ctx, "", jsonOutput, client)
+		assert.EqualError(t, err, "cosmos error")
+		assert.Empty(t, out.String())
+	}
+}

--- a/pkg/cmd/pkg/testdata/invalid/subcommands/dcos-cli-pkg/package.json
+++ b/pkg/cmd/pkg/testdata/invalid/subcommands/dcos-cli-pkg/package.json
@@ -1,0 +1,1 @@
+not a json

--- a/pkg/cmd/pkg/testdata/multiple_commands/subcommands/dcos-cli-pkg/package.json
+++ b/pkg/cmd/pkg/testdata/multiple_commands/subcommands/dcos-cli-pkg/package.json
@@ -1,0 +1,8 @@
+{
+  "description": "Some CLI Package",
+  "framework": true,
+  "minDcosReleaseVersion": "1.12",
+  "name": "pkg-cli",
+  "selected": true,
+  "version": "2.4.4-1.15.4"
+}

--- a/pkg/cmd/pkg/testdata/multiple_commands/subcommands/dcos-pkg-cli/package.json
+++ b/pkg/cmd/pkg/testdata/multiple_commands/subcommands/dcos-pkg-cli/package.json
@@ -1,0 +1,7 @@
+{
+  "description": "Some CLI APP",
+  "framework": true,
+  "name": "cli-app",
+  "selected": true,
+  "version": "alpha"
+}

--- a/python/lib/dcoscli/tests/unit/data/package_search.txt
+++ b/python/lib/dcoscli/tests/unit/data/package_search.txt
@@ -1,4 +1,4 @@
-NAME        VERSION                               SELECTED  FRAMEWORK  DESCRIPTION                                                                       
+NAME        VERSION                               SELECTED  FRAMEWORK  DESCRIPTION
 cassandra   0.1.0-SNAPSHOT-447-master-3ad1bbf8f7  False     True       Apache Cassandra running on Apache Mesos                                          
 chronos     2.3.4                                 False     True       A fault tolerant job scheduler for Mesos which handles dependencies and ISO86...  
 hdfs        0.1.1                                 False     True       Hadoop Distributed File System (HDFS), Highly Available                           

--- a/python/lib/dcoscli/tests/unit/data/package_search.txt
+++ b/python/lib/dcoscli/tests/unit/data/package_search.txt
@@ -1,4 +1,4 @@
-NAME        VERSION                               SELECTED  FRAMEWORK  DESCRIPTION
+NAME        VERSION                               SELECTED  FRAMEWORK  DESCRIPTION                                                                       
 cassandra   0.1.0-SNAPSHOT-447-master-3ad1bbf8f7  False     True       Apache Cassandra running on Apache Mesos                                          
 chronos     2.3.4                                 False     True       A fault tolerant job scheduler for Mesos which handles dependencies and ISO86...  
 hdfs        0.1.1                                 False     True       Hadoop Distributed File System (HDFS), Highly Available                           


### PR DESCRIPTION
To distinguish community and regular packages, add `CERTIFIED` column to `dcos package list` command and change `SELECTED` to `CERTIFIED` in `dcos package search`.

Allow user to filter by part of the name passed as the first argument.

Fixes:
* https://jira.mesosphere.com/browse/DCOS-55773
* https://jira.mesosphere.com/browse/DCOS_OSS-5607