### PR TITLE
Remove DC/OS E2E

### DIFF
--- a/ci/integration-tests-linux.groovy
+++ b/ci/integration-tests-linux.groovy
@@ -37,16 +37,17 @@ pipeline {
           variable: 'DCOS_TEST_LICENSE'],
           [$class: 'UsernamePasswordMultiBinding',
           credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
-          usernameVariable: 'DCOS_TEST_ADMIN_USERNAME',
-          passwordVariable: 'DCOS_TEST_ADMIN_PASSWORD']
+          usernameVariable: 'DCOS_USERNAME',
+          passwordVariable: 'DCOS_PASSWORD']
         ]) {
           unstash 'dcos-linux'
 
           sh '''
             docker run --rm -v $PWD:/usr/src -w /usr/src \
+              -v ${DCOS_TEST_SSH_KEY_PATH}:${DCOS_TEST_SSH_KEY_PATH} \
               -e DCOS_TEST_INSTALLER_URL \
               -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
-              -e DCOS_TEST_ADMIN_USERNAME -e DCOS_TEST_ADMIN_PASSWORD \
+              -e DCOS_USERNAME -e DCOS_PASSWORD \
               -e DCOS_TEST_LICENSE -e DCOS_TEST_SSH_KEY_PATH \
               python:3.7-stretch bash -exc " \
                 mkdir -p build/linux; \
@@ -58,7 +59,7 @@ pipeline {
                 pip install -r requirements.txt; \
                 wget -O env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/linux/x86-64/master/dcos; \
                 dcos cluster remove --all; \
-                ./run_integration_tests.py --e2e-backend=dcos_launch"
+                ./run_integration_tests.py"
           '''
         }
       }

--- a/ci/integration-tests-mac.groovy
+++ b/ci/integration-tests-mac.groovy
@@ -37,8 +37,8 @@ pipeline {
           variable: 'DCOS_TEST_LICENSE'],
           [$class: 'UsernamePasswordMultiBinding',
           credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
-          usernameVariable: 'DCOS_TEST_ADMIN_USERNAME',
-          passwordVariable: 'DCOS_TEST_ADMIN_PASSWORD']
+          usernameVariable: 'DCOS_USERNAME',
+          passwordVariable: 'DCOS_PASSWORD']
         ]) {
           unstash 'dcos-darwin'
 
@@ -56,7 +56,7 @@ pipeline {
               pip install -r requirements.txt; \
               wget -O env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/darwin/x86-64/master/dcos; \
               dcos cluster remove --all; \
-              ./run_integration_tests.py --e2e-backend=dcos_launch"
+              ./run_integration_tests.py"
           '''
         }
       }

--- a/pkg/cmd/pkg/package_install.go
+++ b/pkg/cmd/pkg/package_install.go
@@ -63,7 +63,8 @@ func pkgInstall(ctx api.Context, packageName string, opts pkgInstallOptions) err
 	if opts.optionsPath != "" {
 		_, err := os.Stat(opts.optionsPath)
 		if err != nil {
-			return err
+			ctx.Logger().Debug(err)
+			return fmt.Errorf("couldn't find options file '%s'", opts.optionsPath)
 		}
 	}
 	c, err := cosmos.NewClient(ctx, pluginutil.HTTPClient(""))

--- a/pkg/cmd/pkg/package_install_test.go
+++ b/pkg/cmd/pkg/package_install_test.go
@@ -13,7 +13,7 @@ func TestPkgInstallMutuallyExclusiveOptionsShouldFail(t *testing.T) {
 }
 
 func TestPkgInstallNotExistingOptionsPathShouldFail(t *testing.T) {
-	err := pkgInstall(nil, "helloworld", pkgInstallOptions{optionsPath: "not existing path"})
+	err := pkgInstall(mock.NewContext(nil), "helloworld", pkgInstallOptions{optionsPath: "not existing path"})
 	assert.Error(t, err)
 }
 

--- a/python/lib/dcoscli/tests/integrations/test_package.py
+++ b/python/lib/dcoscli/tests/integrations/test_package.py
@@ -307,7 +307,7 @@ def test_install_missing_options_file():
         ['dcos', 'package', 'install', 'helloworld', '--yes',
          '--options=asdf.json'],
         returncode=1,
-        stderr=b"Error: stat asdf.json: no such file or directory\n")
+        stderr=b"Error: couldn't find options file 'asdf.json'\n")
 
 
 def test_install_app_and_cli():

--- a/scripts/plugin_env.sh
+++ b/scripts/plugin_env.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo "export DCOS_URL=$(dcos config show core.dcos_url)"
-echo "export DCOS_ACS_TOKEN=$(dcos config show core.dcos_acs_token)"
-echo "export DCOS_TLS_INSECURE=1"

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,11 +1,9 @@
---find-links git+https://github.com/dcos/dcos-e2e.git@2019.04.02.1#egg=dcos-e2e-2019.04.02.1
 --find-links git+https://github.com/dcos/dcos-launch.git@08bafb72fe7b0f2a8013d6ec9460e4aeb0e27406#egg=dcos-launch-0.1-dev
 --find-links git+https://github.com/dcos/dcos-test-utils.git@e8519d9c20c4f0859d90a0a1d7eeae5c3c52fe5d#egg=dcos-test-utils-0.1
 boto3==1.9.126
-click==6.7
-dcos-e2e==2019.04.02.1
 dcos_launch==0.1-dev
 dcos-test-utils==0.1
+passlib==1.7.1
 requests==2.21.0
 urllib3==1.24.2
 -e ../python/lib/dcos

--- a/scripts/run_integration_tests.py
+++ b/scripts/run_integration_tests.py
@@ -1,138 +1,42 @@
 #!/usr/bin/env python3
 
 import os
-import urllib.request
-import socket
-import subprocess
 import sys
 import time
 
-from ipaddress import IPv4Address
-from pathlib import Path
-from urllib.parse import urlparse
-
-import click
 import pytest
 
-from dcos_e2e.backends import AWS, Docker
-from dcos_e2e.cluster import Cluster
-from dcos_e2e.node import Node
-
 from dcoscli.test.common import dcos_tempdir, exec_command
-from passlib.hash import sha512_crypt
 
+os.environ["CLI_TEST_SSH_USER"] = "centos"
+os.environ["CLI_TEST_MASTER_PROXY"] = "1"
+os.environ["CLI_TEST_SSH_KEY_PATH"] = os.environ.get('DCOS_TEST_SSH_KEY_PATH')
 
-@click.command()
-@click.option('--e2e-backend', type=click.Choice(['existing', 'dcos_launch', 'dcos_docker']), required=True)
-@click.option('--installer-url', help='URL of the DC/OS installer.')
-@click.option('--dcos-license', envvar='DCOS_TEST_LICENSE', help='Content of the license to use.')
-@click.option('--dcos-url', envvar='DCOS_TEST_URL', help='Specifies the public URL or IP address of the master node.')
-@click.option('--admin-username', help='Username for the admin user.', required=True)
-@click.option('--admin-password', help='Password for the admin user.', required=True)
-@click.option('--ssh-user', default='centos', help='SSH user for connecting to the cluster.')
-@click.option('--ssh-key-path', type=click.Path(), help='Path to the private SSH key for connecting to the cluster.')
-def run_tests(e2e_backend, installer_url, dcos_license, dcos_url, admin_username, admin_password, ssh_user, ssh_key_path):
+code, out, _ = exec_command(['./launch_aws_cluster.py'])
+assert code == 0
 
-    os.environ["CLI_TEST_SSH_USER"] = ssh_user
-    os.environ["CLI_TEST_MASTER_PROXY"] = "1"
-    os.environ["CLI_TEST_SSH_KEY_PATH"] = ssh_key_path
+master_ip = out.decode()
 
-    # extra dcos_config (for dcos_launch and dcos_docker backends)
-    extra_config = {
-        'superuser_username': admin_username,
-        'superuser_password_hash': sha512_crypt.hash(admin_password),
-        'fault_domain_enabled': False,
-        'license_key_contents': dcos_license,
-    }
+with dcos_tempdir():
+    code, _, _ = exec_command(['dcos', 'cluster', 'setup', '--no-check', master_ip])
+    assert code == 0
 
-    if e2e_backend == 'dcos_launch':
-        cluster_backend = AWS()
+    code, _, _ = exec_command(['dcos', 'plugin', 'add', '-u', '../build/' + sys.platform + '/dcos-core-cli.zip'])
+    assert code == 0
 
-        with Cluster(cluster_backend=cluster_backend, agents=1) as cluster:
-            dcos_config = {**cluster.base_config, **extra_config}
+    os.chdir("../python/lib/dcoscli")
 
-            cluster.install_dcos_from_url(
-                dcos_installer=installer_url,
-                dcos_config=dcos_config,
-                ip_detect_path=AWS().ip_detect_path,
-            )
+    retcode = pytest.main([
+        '-vv',
+        '-x',
+        '--durations=10',
+        '-p', 'no:cacheprovider',
+        'tests/integrations'
+    ])
 
-            os.environ["CLI_TEST_SSH_KEY_PATH"] = str(cluster._cluster._ssh_key_path)
+if retcode != 0:
+    print("Sleeping for 5 minutes to leave room for manual debugging...")
+    print(master_ip)
+    time.sleep(300)
 
-            _run_tests(cluster, admin_username, admin_password)
-    elif e2e_backend == 'dcos_docker':
-        dcos_ee_installer_filename = 'dcos_generate_config.ee.sh'
-        dcos_ee_installer_path = Path.cwd() / Path(dcos_ee_installer_filename)
-
-        if not dcos_ee_installer_path.exists():
-            urllib.request.urlretrieve(installer_url, dcos_ee_installer_filename)
-
-        with Cluster(cluster_backend=Docker(), agents=1) as cluster:
-            dcos_config = {**cluster.base_config, **extra_config}
-
-            cluster.install_dcos_from_path(
-                dcos_installer=dcos_ee_installer_path,
-                dcos_config=dcos_config,
-                ip_detect_path=Docker().ip_detect_path,
-            )
-
-            _run_tests(cluster, admin_username, admin_password)
-    elif e2e_backend == 'existing':
-        try:
-            dcos_ip = IPv4Address(dcos_url)
-        except ValueError:
-            parsed_dcos_url = urlparse(dcos_url)
-            dcos_hostname = parsed_dcos_url.hostname
-            dcos_ip = IPv4Address(socket.gethostbyname(dcos_hostname))
-
-        masters = set([Node(
-            public_ip_address=dcos_ip,
-            private_ip_address=dcos_ip,
-            ssh_key_path=Path(ssh_key_path),
-            default_user=ssh_user,
-        )])
-
-        cluster = Cluster.from_nodes(
-            masters=masters,
-            agents=set(),
-            public_agents=set(),
-        )
-
-        _run_tests(cluster, admin_username, admin_password)
-
-
-def _run_tests(cluster, admin_username, admin_password):
-    cluster.wait_for_dcos_ee(
-        superuser_username=admin_username,
-        superuser_password=admin_password,
-    )
-
-    master_node = next(iter(cluster.masters))
-    master_ip = master_node.public_ip_address.exploded
-
-    with dcos_tempdir():
-        print(master_ip)
-        exec_command(['dcos', 'cluster', 'setup', '--no-check', '--username',
-                      admin_username, '--password', admin_password, master_ip])
-
-        exec_command(['dcos', 'plugin', 'add', '-u', '../build/' + sys.platform + '/dcos-core-cli.zip'])
-
-        os.chdir("../python/lib/dcoscli")
-
-        retcode = pytest.main([
-            '-vv',
-            '-x',
-            '--durations=10',
-            '-p', 'no:cacheprovider',
-            'tests/integrations'
-        ])
-
-    if retcode != 0:
-        print("Sleeping for 5 minutes to leave room for manual debugging...")
-        print(master_ip)
-        time.sleep(300)
-
-    sys.exit(retcode)
-
-if __name__ == '__main__':
-    run_tests(auto_envvar_prefix='DCOS_TEST')
+sys.exit(retcode)


### PR DESCRIPTION
Currently we have a mix of DC/OS E2E and DC/OS Launch. We pinned an old
version of DC/OS E2E which doesn't work with DC/OS dev anymore, updating
DC/OS E2E to its latest version would probably fix the issue, this was
tried in #376 without success.

As a simple fix we can remove DC/OS E2E and stick to DC/OS Launch for
now, in the long-term we should move to the universal DC/OS installer.