### PR TITLE
Add marathon command tree as Python wrapper

### DIFF
--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/diagnostics"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/job"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/node"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/pkg"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/quota"
@@ -27,6 +28,7 @@ func NewDCOSCommand(ctx api.Context) *cobra.Command {
 		service.NewCommand(ctx),
 		task.NewCommand(ctx),
 		diagnostics.NewCommand(ctx),
+		marathon.NewCommand(ctx),
 	)
 
 	cmd.SetUsageFunc(pluginutil.Usage)

--- a/pkg/cmd/marathon/app/app.go
+++ b/pkg/cmd/marathon/app/app.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonApp(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "app",
+		Short: "Manage apps",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonAppAdd(ctx),
+		newCmdMarathonAppKill(ctx),
+		newCmdMarathonAppList(ctx),
+		newCmdMarathonAppRemove(ctx),
+		newCmdMarathonAppRestart(ctx),
+		newCmdMarathonAppShow(ctx),
+		newCmdMarathonAppStart(ctx),
+		newCmdMarathonAppStop(ctx),
+		newCmdMarathonAppUpdate(ctx),
+		newCmdMarathonAppVersion(ctx),
+	)
+
+	return cmd
+}
+

--- a/pkg/cmd/marathon/app/app.go
+++ b/pkg/cmd/marathon/app/app.go
@@ -26,4 +26,3 @@ func NewCmdMarathonApp(ctx api.Context) *cobra.Command {
 
 	return cmd
 }
-

--- a/pkg/cmd/marathon/app/app_add.go
+++ b/pkg/cmd/marathon/app/app_add.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppAdd(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_kill.go
+++ b/pkg/cmd/marathon/app/app_kill.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppKill(ctx api.Context) *cobra.Command {
+	var scale bool
+	var host string
+
+	cmd := &cobra.Command{
+		Use:   "kill",
+		Short: "Kill a running application instance.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&scale, "scale", false, "Scale the app down after performing the the operation.")
+	cmd.Flags().StringVar(&host, "host", "", "The hostname that is running app.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_list.go
+++ b/pkg/cmd/marathon/app/app_list.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppList(ctx api.Context) *cobra.Command {
+	var json bool
+	var quiet bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the installed applications.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Display IDs only.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_remove.go
+++ b/pkg/cmd/marathon/app/app_remove.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppRemove(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_restart.go
+++ b/pkg/cmd/marathon/app/app_restart.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppRestart(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "restart",
+		Short: "Restart an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_show.go
+++ b/pkg/cmd/marathon/app/app_show.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+const appVersionDescription = `The version of the application to use. It can be specified as an
+absolute or relative value. Absolute values must be in ISO8601 date
+format. Relative values must be specified as a negative integer and they
+represent the version from the currently deployed application definition.
+`
+
+func newCmdMarathonAppShow(ctx api.Context) *cobra.Command {
+	var appVersion string
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show the `marathon.json` for an  application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().StringVar(&appVersion, "app-version", "", appVersionDescription)
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_start.go
+++ b/pkg/cmd/marathon/app/app_start.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppStart(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_stop.go
+++ b/pkg/cmd/marathon/app/app_stop.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppStop(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_update.go
+++ b/pkg/cmd/marathon/app/app_update.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppUpdate(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/app/app_version_list.go
+++ b/pkg/cmd/marathon/app/app_version_list.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAppVersion(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Manage Marathon app versions.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonAppVersionList(ctx),
+	)
+
+	return cmd
+}
+
+func newCmdMarathonAppVersionList(ctx api.Context) *cobra.Command {
+	var maxCount int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the version history of an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().IntVar(&maxCount, "max-count", 0, "Maximum number of entries to fetch and return.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/debug/debug.go
+++ b/pkg/cmd/marathon/debug/debug.go
@@ -19,4 +19,3 @@ func NewCmdMarathonDebug(ctx api.Context) *cobra.Command {
 
 	return cmd
 }
-

--- a/pkg/cmd/marathon/debug/debug.go
+++ b/pkg/cmd/marathon/debug/debug.go
@@ -1,0 +1,22 @@
+package debug
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonDebug(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "debug",
+		Short: "Debug app deployments.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonDebugDetails(ctx),
+		newCmdMarathonDebugList(ctx),
+		newCmdMarathonDebugSummary(ctx),
+	)
+
+	return cmd
+}
+

--- a/pkg/cmd/marathon/debug/debug_details.go
+++ b/pkg/cmd/marathon/debug/debug_details.go
@@ -1,0 +1,23 @@
+package debug
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDebugDetails(ctx api.Context) *cobra.Command {
+	var json bool
+
+	cmd := &cobra.Command{
+		Use:   "details",
+		Short: "Display detailed information for a queued instance launch for debugging purpose.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/debug/debug_list.go
+++ b/pkg/cmd/marathon/debug/debug_list.go
@@ -1,0 +1,23 @@
+package debug
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDebugList(ctx api.Context) *cobra.Command {
+	var json bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Print a list of currently queued instance launches for debugging purpose.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/debug/debug_summary.go
+++ b/pkg/cmd/marathon/debug/debug_summary.go
@@ -1,0 +1,23 @@
+package debug
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDebugSummary(ctx api.Context) *cobra.Command {
+	var json bool
+
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Display summarized information for a queued instance launch for debugging purpose.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/deployment/deployment.go
+++ b/pkg/cmd/marathon/deployment/deployment.go
@@ -1,0 +1,22 @@
+package deployment
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonDeployment(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deployment",
+		Short: "Manage deployments.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonDeploymentList(ctx),
+		newCmdMarathonDeploymentRollback(ctx),
+		newCmdMarathonDeploymentStop(ctx),
+		newCmdMarathonDeploymentWatch(ctx),
+	)
+
+	return cmd
+}

--- a/pkg/cmd/marathon/deployment/deployment_list.go
+++ b/pkg/cmd/marathon/deployment/deployment_list.go
@@ -1,0 +1,25 @@
+package deployment
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDeploymentList(ctx api.Context) *cobra.Command {
+	var json bool
+	var quiet bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Print a list of currently deployed applications.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Display IDs only for list.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/deployment/deployment_rollback.go
+++ b/pkg/cmd/marathon/deployment/deployment_rollback.go
@@ -1,0 +1,18 @@
+package deployment
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDeploymentRollback(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Short: "Remove a deployed application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/deployment/deployment_stop.go
+++ b/pkg/cmd/marathon/deployment/deployment_stop.go
@@ -1,0 +1,18 @@
+package deployment
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDeploymentStop(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Cancel the in-progress deployment of an application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/deployment/deployment_watch.go
+++ b/pkg/cmd/marathon/deployment/deployment_watch.go
@@ -1,0 +1,26 @@
+package deployment
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDeploymentWatch(ctx api.Context) *cobra.Command {
+	var maxCount int
+	var interval int
+
+	cmd := &cobra.Command{
+		Use:   "watch",
+		Short: "Monitor deployments.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().IntVar(&maxCount, "max-count", 0, "Maximum number of entries to fetch and return.")
+	// TODO: Python version has no description
+	cmd.Flags().IntVar(&interval, "interval", 0, "")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/group/group.go
+++ b/pkg/cmd/marathon/group/group.go
@@ -22,4 +22,3 @@ func NewCmdMarathonGroup(ctx api.Context) *cobra.Command {
 
 	return cmd
 }
-

--- a/pkg/cmd/marathon/group/group.go
+++ b/pkg/cmd/marathon/group/group.go
@@ -1,0 +1,25 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonGroup(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "group",
+		Short: "Manage groups.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonGroupAdd(ctx),
+		newCmdMarathonGroupList(ctx),
+		newCmdMarathonGroupRemove(ctx),
+		newCmdMarathonGroupScale(ctx),
+		newCmdMarathonGroupShow(ctx),
+		newCmdMarathonGroupUpdate(ctx),
+	)
+
+	return cmd
+}
+

--- a/pkg/cmd/marathon/group/group_add.go
+++ b/pkg/cmd/marathon/group/group_add.go
@@ -1,0 +1,23 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonGroupAdd(ctx api.Context) *cobra.Command {
+	var groupID string
+
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a group.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().StringVar(&groupID, "id", "", "The group ID to add.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/group/group_list.go
+++ b/pkg/cmd/marathon/group/group_list.go
@@ -1,0 +1,23 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonGroupList(ctx api.Context) *cobra.Command {
+	var json bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Print the list of groups.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/group/group_remove.go
+++ b/pkg/cmd/marathon/group/group_remove.go
@@ -1,0 +1,23 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonGroupRemove(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a group.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/group/group_scale.go
+++ b/pkg/cmd/marathon/group/group_scale.go
@@ -10,8 +10,9 @@ func newCmdMarathonGroupScale(ctx api.Context) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "scale",
-		Short: "Scale a group.",
+		Use:                "scale",
+		Short:              "Scale a group.",
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return python.InvokePythonCLI(ctx)
 		},

--- a/pkg/cmd/marathon/group/group_scale.go
+++ b/pkg/cmd/marathon/group/group_scale.go
@@ -1,0 +1,23 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonGroupScale(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "scale",
+		Short: "Scale a group.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/group/group_show.go
+++ b/pkg/cmd/marathon/group/group_show.go
@@ -1,0 +1,28 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+const groupVersionDescription = `The group version to use for the command. It can be specified as an
+absolute or relative value. Absolute values must be in ISO8601 date
+format. Relative values must be specified as a negative integer and they
+represent the version from the currently deployed group definition.`
+
+func newCmdMarathonGroupShow(ctx api.Context) *cobra.Command {
+	var groupVersion string
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Print a detailed list of groups.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().StringVar(&groupVersion, "group-version", "", groupVersionDescription)
+
+	return cmd
+}

--- a/pkg/cmd/marathon/group/group_update.go
+++ b/pkg/cmd/marathon/group/group_update.go
@@ -1,0 +1,23 @@
+package group
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonGroupUpdate(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a group.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/leader/leader.go
+++ b/pkg/cmd/marathon/leader/leader.go
@@ -18,4 +18,3 @@ func NewCmdMarathonLeader(ctx api.Context) *cobra.Command {
 
 	return cmd
 }
-

--- a/pkg/cmd/marathon/leader/leader.go
+++ b/pkg/cmd/marathon/leader/leader.go
@@ -1,0 +1,21 @@
+package leader
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonLeader(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "leader",
+		Short: "Manage leader.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonLeaderDelete(ctx),
+		newCmdMarathonLeaderShow(ctx),
+	)
+
+	return cmd
+}
+

--- a/pkg/cmd/marathon/leader/leader_delete.go
+++ b/pkg/cmd/marathon/leader/leader_delete.go
@@ -1,0 +1,17 @@
+package leader
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonLeaderDelete(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "delete",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/leader/leader_show.go
+++ b/pkg/cmd/marathon/leader/leader_show.go
@@ -1,0 +1,22 @@
+package leader
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonLeaderShow(ctx api.Context) *cobra.Command {
+	var json bool
+
+	cmd := &cobra.Command{
+		Use: "show",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/marathon.go
+++ b/pkg/cmd/marathon/marathon.go
@@ -1,0 +1,56 @@
+package marathon
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/app"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/debug"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/deployment"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/group"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/leader"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/pod"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/task"
+	"github.com/spf13/cobra"
+)
+
+// NewCommand creates the `dcos package` subcommand.
+func NewCommand(ctx api.Context) *cobra.Command {
+	var configSchema bool
+	var info bool
+	var version bool
+
+	cmd := &cobra.Command{
+		Use:   "marathon",
+		Short: "Deploy and manage applications to DC/OS",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			/*
+				if len(args) == 0 {
+					return cmd.Help()
+				}
+				fmt.Fprintln(ctx.ErrOut(), cmd.UsageString())
+				return fmt.Errorf("unknown command %s", args[0])
+			*/
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&configSchema, "config-schema", false, "Show the configuration schema for the Marathon subcommand.")
+	cmd.Flags().BoolVar(&info, "info", false, "Print a short description of this subcommand.")
+	cmd.Flags().BoolVar(&version, "version", false, "Print version information")
+
+	cmd.AddCommand(
+		newCmdMarathonAbout(ctx),
+		newCmdMarathonDelay(ctx),
+		newCmdMarathonPing(ctx),
+		newCmdMarathonPlugin(ctx),
+		app.NewCmdMarathonApp(ctx),
+		debug.NewCmdMarathonDebug(ctx),
+		deployment.NewCmdMarathonDeployment(ctx),
+		group.NewCmdMarathonGroup(ctx),
+		leader.NewCmdMarathonLeader(ctx),
+		pod.NewCmdMarathonPod(ctx),
+		task.NewCmdMarathonTask(ctx),
+	)
+
+	return cmd
+}

--- a/pkg/cmd/marathon/marathon_about.go
+++ b/pkg/cmd/marathon/marathon_about.go
@@ -1,0 +1,17 @@
+package marathon
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonAbout(ctx api.Context) *cobra.Command {
+	return &cobra.Command{
+		Use:   "about",
+		Short: "Print info.json for DC/OS Marathon.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+}

--- a/pkg/cmd/marathon/marathon_delay_reset.go
+++ b/pkg/cmd/marathon/marathon_delay_reset.go
@@ -1,0 +1,30 @@
+package marathon
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonDelay(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delay",
+		Short: "Control Marathon deployment delay.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonDelayReset(ctx),
+	)
+	return cmd
+}
+
+func newCmdMarathonDelayReset(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset the current delay (if any) of the application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/marathon_ping.go
+++ b/pkg/cmd/marathon/marathon_ping.go
@@ -1,0 +1,24 @@
+package marathon
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPing(ctx api.Context) *cobra.Command {
+	var once bool
+
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Ensure Marathon is up and responding.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	// TODO: the Python help output doesn't give this a description also it already only pings once so what does this do?
+	cmd.Flags().BoolVar(&once, "once", false, "")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/marathon_plugin_list.go
+++ b/pkg/cmd/marathon/marathon_plugin_list.go
@@ -1,0 +1,36 @@
+package marathon
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPlugin(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage Marathon plugins.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonPluginList(ctx),
+	)
+
+	return cmd
+}
+
+func newCmdMarathonPluginList(ctx api.Context) *cobra.Command {
+	var json bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List plugins.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/pod/pod.go
+++ b/pkg/cmd/marathon/pod/pod.go
@@ -1,0 +1,25 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonPod(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pod",
+		Short: "Manage pods.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonPodAdd(ctx),
+		newCmdMarathonPodKill(ctx),
+		newCmdMarathonPodList(ctx),
+		newCmdMarathonPodRemove(ctx),
+		newCmdMarathonPodShow(ctx),
+		newCmdMarathonPodUpdate(ctx),
+	)
+
+	return cmd
+}
+

--- a/pkg/cmd/marathon/pod/pod.go
+++ b/pkg/cmd/marathon/pod/pod.go
@@ -22,4 +22,3 @@ func NewCmdMarathonPod(ctx api.Context) *cobra.Command {
 
 	return cmd
 }
-

--- a/pkg/cmd/marathon/pod/pod_add.go
+++ b/pkg/cmd/marathon/pod/pod_add.go
@@ -1,0 +1,18 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPodAdd(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add a pod.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/pod/pod_kill.go
+++ b/pkg/cmd/marathon/pod/pod_kill.go
@@ -1,0 +1,18 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPodKill(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kill",
+		Short: "Kill one or more running pod instances.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/pod/pod_list.go
+++ b/pkg/cmd/marathon/pod/pod_list.go
@@ -1,0 +1,25 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPodList(ctx api.Context) *cobra.Command {
+	var json bool
+	var quiet bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the deployed pods.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/pod/pod_remove.go
+++ b/pkg/cmd/marathon/pod/pod_remove.go
@@ -1,0 +1,18 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPodRemove(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove a pod.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/pod/pod_remove.go
+++ b/pkg/cmd/marathon/pod/pod_remove.go
@@ -7,6 +7,8 @@ import (
 )
 
 func newCmdMarathonPodRemove(ctx api.Context) *cobra.Command {
+	var force bool
+
 	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove a pod.",
@@ -14,5 +16,8 @@ func newCmdMarathonPodRemove(ctx api.Context) *cobra.Command {
 			return python.InvokePythonCLI(ctx)
 		},
 	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
 	return cmd
 }

--- a/pkg/cmd/marathon/pod/pod_show.go
+++ b/pkg/cmd/marathon/pod/pod_show.go
@@ -1,0 +1,18 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPodShow(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Display detailed information for a specific pod.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/pod/pod_update.go
+++ b/pkg/cmd/marathon/pod/pod_update.go
@@ -1,0 +1,23 @@
+package pod
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonPodUpdate(ctx api.Context) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a pod.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable checks in Marathon during updates.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/python/cli.go
+++ b/pkg/cmd/marathon/python/cli.go
@@ -1,0 +1,45 @@
+package python
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/dcos/dcos-cli/api"
+)
+
+func InvokePythonCLI(ctx api.Context) error {
+	pythonBinaryPath, _ := ctx.EnvLookup("DCOS_CLI_EXPERIMENTAL_PATH_DCOS_PY")
+	if len(strings.TrimSpace(pythonBinaryPath)) == 0 {
+		executablePath, err := os.Executable()
+		if err != nil {
+			return err
+		}
+
+		pythonBinaryPath = filepath.Join(filepath.Dir(executablePath), "dcos_py")
+		if runtime.GOOS == "windows" {
+			pythonBinaryPath += ".exe"
+		}
+	}
+
+	if _, err := os.Stat(pythonBinaryPath); os.IsNotExist(err) {
+		return errors.New(pythonBinaryPath + " does not exist")
+	}
+
+	execCmd := exec.Command(pythonBinaryPath, ctx.Args()[1:]...)
+	execCmd.Stdout = ctx.Out()
+	execCmd.Stderr = ctx.ErrOut()
+	execCmd.Stdin = ctx.Input()
+
+	err := execCmd.Run()
+
+	if execCmd.ProcessState.Exited() {
+		exitCode := execCmd.ProcessState.ExitCode()
+		os.Exit(exitCode)
+	}
+
+	return err
+}

--- a/pkg/cmd/marathon/task/task.go
+++ b/pkg/cmd/marathon/task/task.go
@@ -20,4 +20,3 @@ func NewCmdMarathonTask(ctx api.Context) *cobra.Command {
 
 	return cmd
 }
-

--- a/pkg/cmd/marathon/task/task.go
+++ b/pkg/cmd/marathon/task/task.go
@@ -1,0 +1,23 @@
+package task
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdMarathonTask(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "task",
+		Short: "Manage tasks.",
+	}
+
+	cmd.AddCommand(
+		newCmdMarathonTaskKill(ctx),
+		newCmdMarathonTaskList(ctx),
+		newCmdMarathonTaskShow(ctx),
+		newCmdMarathonTaskStop(ctx),
+	)
+
+	return cmd
+}
+

--- a/pkg/cmd/marathon/task/task_kill.go
+++ b/pkg/cmd/marathon/task/task_kill.go
@@ -1,0 +1,27 @@
+package task
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonTaskKill(ctx api.Context) *cobra.Command {
+	var scale bool
+	var wipe bool
+	var json bool
+
+	cmd := &cobra.Command{
+		Use:   "kill",
+		Short: "Kill one or more tasks.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&scale, "scale", false, "Scale the app down after performing the the operation.")
+	cmd.Flags().BoolVar(&wipe, "wipe", false, "Wipe persistent data.")
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/task/task_list.go
+++ b/pkg/cmd/marathon/task/task_list.go
@@ -1,0 +1,25 @@
+package task
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonTaskList(ctx api.Context) *cobra.Command {
+	var json bool
+	var quiet bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all tasks.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&json, "json", false, "Print JSON-formatted data.")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Display IDs only.")
+
+	return cmd
+}

--- a/pkg/cmd/marathon/task/task_show.go
+++ b/pkg/cmd/marathon/task/task_show.go
@@ -1,0 +1,18 @@
+package task
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonTaskShow(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "List a specific task.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/marathon/task/task_stop.go
+++ b/pkg/cmd/marathon/task/task_stop.go
@@ -1,0 +1,23 @@
+package task
+
+import (
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon/python"
+	"github.com/spf13/cobra"
+)
+
+func newCmdMarathonTaskStop(ctx api.Context) *cobra.Command {
+	var wipe bool
+
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop a task.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return python.InvokePythonCLI(ctx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&wipe, "wipe", false, "Wipe persistent data.")
+
+	return cmd
+}

--- a/python/lib/dcoscli/tests/data/marathon/help.txt
+++ b/python/lib/dcoscli/tests/data/marathon/help.txt
@@ -1,0 +1,40 @@
+Deploy and manage applications to DC/OS
+
+Usage:
+    dcos marathon [command]
+
+Commands:
+    about
+        Print info.json for DC/OS Marathon.
+    app
+        Manage apps
+    debug
+        Debug app deployments.
+    delay
+        Control Marathon deployment delay.
+    deployment
+        Manage deployments.
+    group
+        Manage groups.
+    leader
+        Manage leader.
+    ping
+        Ensure Marathon is up and responding.
+    plugin
+        Manage Marathon plugins.
+    pod
+        Manage pods.
+    task
+        Manage tasks.
+
+Options:
+    --config-schema
+        Show the configuration schema for the Marathon subcommand.
+    -h, --help
+        help for marathon
+    --info
+        Print a short description of this subcommand.
+    --version
+        Print version information
+
+Use "dcos marathon [command] --help" for more information about a command.

--- a/python/lib/dcoscli/tests/integrations/test_help.py
+++ b/python/lib/dcoscli/tests/integrations/test_help.py
@@ -8,7 +8,7 @@ def test_help_job():
 
 
 def test_help_marathon():
-    with open('dcoscli/data/help/marathon.txt') as content:
+    with open('tests/data/marathon/help.txt') as content:
         assert_command(['dcos', 'help', 'marathon'],
                        stdout=content.read().encode('utf-8'))
 

--- a/python/lib/dcoscli/tests/integrations/test_marathon.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon.py
@@ -26,7 +26,7 @@ _ZERO_INSTANCE_APP_INSTANCES = 100
 
 
 def test_help():
-    with open('dcoscli/data/help/marathon.txt') as content:
+    with open('tests/data/marathon/help.txt') as content:
         assert_command(['dcos', 'marathon', '--help'],
                        stdout=content.read().encode('utf-8'))
 

--- a/scripts/plugin/package_plugin.py
+++ b/scripts/plugin/package_plugin.py
@@ -18,7 +18,7 @@ description = "Deploy and manage jobs in DC/OS"
 
 [[commands]]
 name = "marathon"
-path = "bin/dcos_py{0}"
+path = "bin/dcos{0}"
 description = "Deploy and manage applications to DC/OS"
 
 [[commands]]


### PR DESCRIPTION
Adds marathon and all its subcommands and flags to the core CLI. Currently all commands are wrappers around the Python CLI but this will make it easy to rewrite individual commands.

Addresses: https://jira.mesosphere.com/browse/DCOS-60348