### PR TITLE
Prepare 2.0-patch.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0-patch.x
 
+## 2.0-patch.4
+
 * Features
 
   * Add a `CERTIFIED` column to `dcos package list` and `dcos package search` commands
@@ -10,6 +12,7 @@
 
   * Add better error descriptions for `node diagnostics` command.
   * Fix the `--app-id` filter in `dcos package list`
+  * Fixing incorrect DC/OS version string in diagnostics subcommand
 
 ## 2.0-patch.3
 

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mesos/mesos-go v0.0.10 h1:+M/7Zlkvw4MolkLvXHfj6hkDsLLHOOU54CmOkOUaNBc=
 github.com/mesos/mesos-go v0.0.11-0.20190717023829-56ac038085ac h1:Psyp4ihyc+sazWXeR4Wo2Sbcemgym+z0sOIDdhOFAXo=
 github.com/mesos/mesos-go v0.0.11-0.20190717023829-56ac038085ac/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/pkg/cmd/job/job_test.go
+++ b/pkg/cmd/job/job_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,17 +29,17 @@ func TestParseJSONJob(t *testing.T) {
 	job, err := parseJSONJob(reader)
 	require.NoError(t, err)
 
-	require.Equal(t, "sleepy-test-docker", job.ID)
-	require.Equal(t, "A job that sleeps", job.Description)
+	assert.Equal(t, "sleepy-test-docker", job.ID)
+	assert.Equal(t, "A job that sleeps", job.Description)
 
 	// Run
-	require.Equal(t, "echo 'Snoozing ...'; sleep 10; echo 'Awake now!'", job.Run.Cmd)
-	require.Equal(t, float32(2), job.Run.Cpus)
-	require.Equal(t, 32, job.Run.Mem)
-	require.Equal(t, 10, job.Run.Disk)
+	assert.Equal(t, "echo 'Snoozing ...'; sleep 10; echo 'Awake now!'", job.Run.Cmd)
+	assert.Equal(t, float32(2), job.Run.Cpus)
+	assert.Equal(t, 32, job.Run.Mem)
+	assert.Equal(t, 10, job.Run.Disk)
 
 	// Docker
-	require.Equal(t, "alpine:latest", job.Run.Docker.Image)
-	require.True(t, job.Run.Docker.ForcePullImage)
-	require.True(t, job.Run.Docker.Privileged)
+	assert.Equal(t, "alpine:latest", job.Run.Docker.Image)
+	assert.True(t, job.Run.Docker.ForcePullImage)
+	assert.True(t, job.Run.Docker.Privileged)
 }

--- a/pkg/cmd/node/node_diagnostics.go
+++ b/pkg/cmd/node/node_diagnostics.go
@@ -14,7 +14,7 @@ func newCmdNodeDiagnostics(ctx api.Context) *cobra.Command {
 		Use:   "diagnostics",
 		Short: "Use diagnostics bundles",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/node/node_diagnostics_cancel.go
+++ b/pkg/cmd/node/node_diagnostics_cancel.go
@@ -15,7 +15,7 @@ func newCmdNodeDiagnosticsCancel(ctx api.Context) *cobra.Command {
 		Short: "Cancel a running diagnostics job",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/node/node_diagnostics_create.go
+++ b/pkg/cmd/node/node_diagnostics_create.go
@@ -13,7 +13,7 @@ func newCmdNodeDiagnosticsCreate(ctx api.Context) *cobra.Command {
 		Short: "Create a diagnostics bundle",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics create' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics create' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/node/node_diagnostics_delete.go
+++ b/pkg/cmd/node/node_diagnostics_delete.go
@@ -13,7 +13,7 @@ func newCmdNodeDiagnosticsDelete(ctx api.Context) *cobra.Command {
 		Short: "Delete a diagnostics bundle",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics delete' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics delete' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/node/node_diagnostics_download.go
+++ b/pkg/cmd/node/node_diagnostics_download.go
@@ -17,7 +17,7 @@ func newCmdNodeDiagnosticsDownload(ctx api.Context) *cobra.Command {
 		Short: "Download a diagnostics bundle",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics download' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics download' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/node/node_diagnostics_list.go
+++ b/pkg/cmd/node/node_diagnostics_list.go
@@ -17,7 +17,7 @@ func newCmdNodeDiagnosticsList(ctx api.Context) *cobra.Command {
 		Short: "List available diagnostics bundles",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics list' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics list' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/node/node_diagnostics_status.go
+++ b/pkg/cmd/node/node_diagnostics_status.go
@@ -16,7 +16,7 @@ func newCmdNodeDiagnosticsStatus(ctx api.Context) *cobra.Command {
 		Short: "Print diagnostics job status",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := ctx.Deprecated("This command is deprecated since DC/OS 1.14, please use 'dcos diagnostics list' instead.")
+			err := ctx.Deprecated("This command is deprecated since DC/OS 2.0, please use 'dcos diagnostics list' instead.")
 			if err != nil {
 				return err
 			}

--- a/pkg/diagnostics/v2/client_test.go
+++ b/pkg/diagnostics/v2/client_test.go
@@ -149,8 +149,8 @@ func TestDeleteWithEmptyID(t *testing.T) {
 	err := c.Delete("")
 	assert.Error(t, err)
 	httpError, ok := err.(*httpclient.HTTPError)
-	assert.True(t, ok, "unexpected error: %#v", err)
-	assert.NotNil(t, httpError.Response)
+	require.True(t, ok, "unexpected error: %#v", err)
+	require.NotNil(t, httpError.Response)
 	assert.Equal(t, httpError.Response.StatusCode, http.StatusMethodNotAllowed)
 	assert.Equal(t, "HTTP 405 error", httpError.Error())
 }
@@ -243,8 +243,8 @@ func TestCreateServerError(t *testing.T) {
 	assert.Empty(t, id)
 
 	httpError, ok := err.(*httpclient.HTTPError)
-	assert.True(t, ok, "unexpected error: %#v", err)
-	assert.NotNil(t, httpError.Response)
+	require.True(t, ok, "unexpected error: %#v", err)
+	require.NotNil(t, httpError.Response)
 	assert.Equal(t, httpError.Response.StatusCode, 500)
 	assert.Equal(t, "HTTP 500 error", httpError.Error())
 }

--- a/pkg/logs/client_test.go
+++ b/pkg/logs/client_test.go
@@ -125,10 +125,10 @@ func TestPrintComponent(t *testing.T) {
 		switch fixture.format {
 		case "json", "json-pretty":
 			var entry JournalctlJSONEntry
-			require.NoError(t, json.Unmarshal([]byte(b.String()), &entry))
-			require.Equal(t, entry, infoEntry.JournalctlJSON())
+			assert.NoError(t, json.Unmarshal([]byte(b.String()), &entry))
+			assert.Equal(t, entry, infoEntry.JournalctlJSON())
 		default:
-			require.Equal(t, fixture.expectedOutput, b.String())
+			assert.Equal(t, fixture.expectedOutput, b.String())
 		}
 
 		ts.Close()
@@ -199,7 +199,7 @@ func TestPrintTask(t *testing.T) {
 		err := c.PrintTask(fixture.task, fixture.file, opts)
 		require.NoError(t, err)
 
-		require.Equal(t, fixture.expectedOutput, b.String())
+		assert.Equal(t, fixture.expectedOutput, b.String())
 
 		ts.Close()
 	}

--- a/pkg/mesos/client_test.go
+++ b/pkg/mesos/client_test.go
@@ -33,7 +33,7 @@ func TestHosts(t *testing.T) {
 
 	hosts, err := c.Hosts("8.8.8.8")
 	require.NoError(t, err)
-	require.Equal(t, expectedHosts, hosts)
+	assert.Equal(t, expectedHosts, hosts)
 }
 
 func TestLeader(t *testing.T) {
@@ -55,7 +55,7 @@ func TestLeader(t *testing.T) {
 
 	leader, err := c.Leader()
 	require.NoError(t, err)
-	require.Equal(t, &expectedHosts[0], leader)
+	assert.Equal(t, &expectedHosts[0], leader)
 }
 
 func TestMasters(t *testing.T) {
@@ -77,7 +77,7 @@ func TestMasters(t *testing.T) {
 
 	masters, err := c.Masters()
 	require.NoError(t, err)
-	require.Equal(t, expectedHosts, masters)
+	assert.Equal(t, expectedHosts, masters)
 }
 
 func TestState(t *testing.T) {
@@ -99,7 +99,7 @@ func TestState(t *testing.T) {
 
 	s, err := c.State()
 	require.NoError(t, err)
-	require.Equal(t, &expectedState, s)
+	assert.Equal(t, &expectedState, s)
 }
 
 func TestStateSummary(t *testing.T) {
@@ -126,9 +126,9 @@ func TestStateSummary(t *testing.T) {
 
 	ss, err := c.StateSummary()
 	require.NoError(t, err)
-	require.Equal(t, expectedState.Hostname, ss.Hostname)
-	require.Equal(t, expectedState.Cluster, ss.Cluster)
-	require.Equal(t, expectedState.Slaves, ss.Slaves)
+	assert.Equal(t, expectedState.Hostname, ss.Hostname)
+	assert.Equal(t, expectedState.Cluster, ss.Cluster)
+	assert.Equal(t, expectedState.Slaves, ss.Slaves)
 }
 
 func TestAgents(t *testing.T) {
@@ -160,7 +160,7 @@ func TestAgents(t *testing.T) {
 
 	agents, err := c.Agents()
 	require.NoError(t, err)
-	require.Equal(t, expectedAgents.GetAgents.Agents, agents)
+	assert.Equal(t, expectedAgents.GetAgents.Agents, agents)
 }
 
 func TestMarkAgentGone(t *testing.T) {

--- a/pkg/mesos/taskio.go
+++ b/pkg/mesos/taskio.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -77,6 +78,11 @@ func NewTaskIO(containerID mesos.ContainerID, opts TaskIOOpts) (*TaskIO, error) 
 	}
 	if opts.Stderr == nil {
 		opts.Stderr = os.Stderr
+	}
+	if opts.Logger == nil {
+		logger := logrus.New()
+		logger.Out = ioutil.Discard
+		opts.Logger = logger
 	}
 	if opts.HeartbeatInterval == 0 {
 		opts.HeartbeatInterval = defaultHeartbeatInterval

--- a/pkg/mesos/taskio_test.go
+++ b/pkg/mesos/taskio_test.go
@@ -1,0 +1,224 @@
+package mesos
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	mesos "github.com/mesos/mesos-go/api/v1/lib"
+	"github.com/mesos/mesos-go/api/v1/lib/agent"
+	agentcalls "github.com/mesos/mesos-go/api/v1/lib/agent/calls"
+	"github.com/mesos/mesos-go/api/v1/lib/encoding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAttach(t *testing.T) {
+	containerID := mesos.ContainerID{
+		Value: "my_container",
+		Parent: &mesos.ContainerID{
+			Value: "my_parent_container",
+		},
+	}
+
+	messages := []agent.ProcessIO{
+		processIOData(agent.ProcessIO_Data_STDOUT, []byte("Hello")),
+		processIOData(agent.ProcessIO_Data_STDERR, []byte("[INFO] This is fine\n")),
+		processIOData(agent.ProcessIO_Data_STDOUT, []byte(" world!")),
+	}
+
+	sender := agentcalls.SenderFunc(func(ctx context.Context, r agentcalls.Request) (mesos.Response, error) {
+		var decoder encoding.Decoder
+
+		switch r.Call().Type {
+
+		case agent.Call_ATTACH_CONTAINER_OUTPUT:
+			if assert.NotNil(t, r.Call().AttachContainerOutput) {
+				assert.Equal(t, containerID.Value, r.Call().AttachContainerOutput.ContainerID.Value)
+			}
+
+			decoder = encoding.DecoderFunc(func(u encoding.Unmarshaler) error {
+				msg, ok := u.(*agent.ProcessIO)
+				require.True(t, ok)
+
+				if len(messages) == 0 {
+					return io.EOF
+				}
+				*msg = messages[0]
+				messages = messages[1:]
+				return nil
+			})
+
+		case agent.Call_WAIT_CONTAINER:
+			if assert.NotNil(t, r.Call().WaitContainer) {
+				assert.Equal(t, containerID.Value, r.Call().WaitContainer.ContainerID.Value)
+			}
+
+			decoder = encoding.DecoderFunc(func(u encoding.Unmarshaler) error {
+				r, ok := u.(*agent.Response)
+				require.True(t, ok)
+
+				exitStatus := int32(0)
+				r.WaitContainer = &agent.Response_WaitContainer{
+					ExitStatus: &exitStatus,
+				}
+				return nil
+			})
+
+		default:
+			return nil, fmt.Errorf("unexpected call type %s", r.Call().Type)
+		}
+
+		return &mesos.ResponseWrapper{
+			Decoder: decoder,
+		}, nil
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	opts := TaskIOOpts{
+		Sender: sender,
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	taskIO, err := NewTaskIO(containerID, opts)
+	require.NoError(t, err)
+
+	exitCode, err := taskIO.Attach()
+	require.NoError(t, err)
+
+	assert.Equal(t, "Hello world!", stdout.String())
+	assert.Equal(t, "[INFO] This is fine\n", stderr.String())
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestExec(t *testing.T) {
+	containerID := mesos.ContainerID{
+		Value: "my_container",
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	opts := TaskIOOpts{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	taskIO, err := NewTaskIO(containerID, opts)
+	require.NoError(t, err)
+
+	messages := []agent.ProcessIO{
+		processIOData(agent.ProcessIO_Data_STDOUT, []byte("Hello")),
+		processIOData(agent.ProcessIO_Data_STDERR, []byte("[INFO] This is fine\n")),
+		processIOData(agent.ProcessIO_Data_STDOUT, []byte(" world!")),
+	}
+
+	taskIO.opts.Sender = agentcalls.SenderFunc(func(ctx context.Context, r agentcalls.Request) (mesos.Response, error) {
+		var decoder encoding.Decoder
+
+		switch r.Call().Type {
+
+		case agent.Call_LAUNCH_NESTED_CONTAINER_SESSION:
+
+			call := r.Call().LaunchNestedContainerSession
+			if assert.NotNil(t, call) {
+
+				parentContainer := call.ContainerID.Parent
+				if assert.NotNil(t, parentContainer) {
+					assert.Equal(t, "my_container", parentContainer.Value)
+				}
+
+				cmdInfo := call.Command
+				if assert.NotNil(t, cmdInfo) {
+					assert.Equal(t, []string{"exit", "10"}, cmdInfo.Arguments)
+				}
+			}
+
+			decoder = encoding.DecoderFunc(func(u encoding.Unmarshaler) error {
+				msg, ok := u.(*agent.ProcessIO)
+				require.True(t, ok)
+
+				if len(messages) == 0 {
+					return io.EOF
+				}
+				*msg = messages[0]
+				messages = messages[1:]
+				return nil
+			})
+
+		case agent.Call_WAIT_CONTAINER:
+			if assert.NotNil(t, r.Call().WaitContainer) {
+				assert.Equal(t, taskIO.containerID.Value, r.Call().WaitContainer.ContainerID.Value)
+			}
+
+			decoder = encoding.DecoderFunc(func(u encoding.Unmarshaler) error {
+				r, ok := u.(*agent.Response)
+				require.True(t, ok)
+
+				exitStatus := int32(10 << 8) // exited with 10
+
+				r.WaitContainer = &agent.Response_WaitContainer{
+					ExitStatus: &exitStatus,
+				}
+				return nil
+			})
+
+		default:
+			return nil, fmt.Errorf("unexpected call type %s", r.Call().Type)
+		}
+
+		return &mesos.ResponseWrapper{
+			Decoder: decoder,
+		}, nil
+	})
+
+	exitCode, err := taskIO.Exec("exit", "10")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Hello world!", stdout.String())
+	assert.Equal(t, "[INFO] This is fine\n", stderr.String())
+	assert.Equal(t, 10, exitCode)
+}
+
+func TestLaunchNestedContainerSessionCall(t *testing.T) {
+	containerID := mesos.ContainerID{
+		Value: "my_container",
+	}
+
+	opts := TaskIOOpts{
+		User: "mario",
+		TTY:  true,
+	}
+
+	taskIO, err := NewTaskIO(containerID, opts)
+	require.NoError(t, err)
+
+	call := taskIO.launchNestedContainerSessionCall("exit", "10")
+
+	// ContainerID
+	assert.Equal(t, "my_container", call.LaunchNestedContainerSession.ContainerID.Parent.Value)
+
+	// Command
+	assert.Equal(t, &opts.User, call.LaunchNestedContainerSession.Command.User)
+	assert.Equal(t, "exit", *call.LaunchNestedContainerSession.Command.Value)
+	assert.Equal(t, []string{"exit", "10"}, call.LaunchNestedContainerSession.Command.Arguments)
+
+	// Container
+	assert.Equal(t, mesos.ContainerInfo_MESOS.Enum(), call.LaunchNestedContainerSession.Container.Type)
+	assert.NotNil(t, &opts.User, call.LaunchNestedContainerSession.Container.TTYInfo)
+}
+
+func processIOData(kind agent.ProcessIO_Data_Type, data []byte) agent.ProcessIO {
+	return agent.ProcessIO{
+		Type: agent.ProcessIO_DATA,
+		Data: &agent.ProcessIO_Data{
+			Type: kind,
+			Data: data,
+		},
+	}
+}

--- a/pkg/mesos/types_test.go
+++ b/pkg/mesos/types_test.go
@@ -3,7 +3,7 @@ package mesos
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIP(t *testing.T) {
@@ -12,5 +12,5 @@ func TestIP(t *testing.T) {
 
 	slaveIP := slave.IP()
 
-	require.Equal(t, slaveIP, "172.31.15.225")
+	assert.Equal(t, slaveIP, "172.31.15.225")
 }

--- a/pkg/metrics/client_test.go
+++ b/pkg/metrics/client_test.go
@@ -40,5 +40,5 @@ func TestNode(t *testing.T) {
 
 	node, err := c.Node("mesosID")
 	require.NoError(t, err)
-	require.Equal(t, &expectedNode, node)
+	assert.Equal(t, &expectedNode, node)
 }

--- a/pkg/metronome/client_test.go
+++ b/pkg/metronome/client_test.go
@@ -28,7 +28,7 @@ func TestJob(t *testing.T) {
 
 	job, err := c.Job("test-job")
 	require.NoError(t, err)
-	require.Equal(t, &expectedJob, job)
+	assert.Equal(t, &expectedJob, job)
 }
 
 func TestJobs(t *testing.T) {
@@ -58,7 +58,7 @@ func TestJobs(t *testing.T) {
 
 	jobs, err := c.Jobs()
 	require.NoError(t, err)
-	require.Equal(t, expectedJobs, jobs)
+	assert.Equal(t, expectedJobs, jobs)
 }
 
 func TestAddJob(t *testing.T) {
@@ -82,7 +82,7 @@ func TestAddJob(t *testing.T) {
 
 	job, err := c.AddJob(&expectedJob)
 	require.NoError(t, err)
-	require.Equal(t, &expectedJob, job)
+	assert.Equal(t, &expectedJob, job)
 }
 
 func TestUpdateJob(t *testing.T) {
@@ -106,7 +106,7 @@ func TestUpdateJob(t *testing.T) {
 
 	job, err := c.UpdateJob(&expectedJob)
 	require.NoError(t, err)
-	require.Equal(t, &expectedJob, job)
+	assert.Equal(t, &expectedJob, job)
 }
 
 func TestRunJob(t *testing.T) {
@@ -127,7 +127,7 @@ func TestRunJob(t *testing.T) {
 
 	run, err := c.RunJob("test-job")
 	require.NoError(t, err)
-	require.Equal(t, &expectedRun, run)
+	assert.Equal(t, &expectedRun, run)
 }
 
 func TestRun(t *testing.T) {
@@ -147,7 +147,7 @@ func TestRun(t *testing.T) {
 
 	run, err := c.Run("test-job", "20190307204634kC8Rs")
 	require.NoError(t, err)
-	require.Equal(t, &expectedRun, run)
+	assert.Equal(t, &expectedRun, run)
 }
 
 func TestRuns(t *testing.T) {
@@ -174,7 +174,7 @@ func TestRuns(t *testing.T) {
 
 	runs, err := c.Runs("test-job")
 	require.NoError(t, err)
-	require.Equal(t, expectedRuns, runs)
+	assert.Equal(t, expectedRuns, runs)
 }
 
 func TestKill(t *testing.T) {
@@ -231,7 +231,7 @@ func TestSchedules(t *testing.T) {
 
 	schedules, err := c.Schedules("test-job")
 	require.NoError(t, err)
-	require.Equal(t, expectedSchedules, schedules)
+	assert.Equal(t, expectedSchedules, schedules)
 }
 
 func TestAddSchedule(t *testing.T) {
@@ -255,7 +255,7 @@ func TestAddSchedule(t *testing.T) {
 
 	schedule, err := c.AddSchedule("test-job", &expectedSchedule)
 	require.NoError(t, err)
-	require.Equal(t, &expectedSchedule, schedule)
+	assert.Equal(t, &expectedSchedule, schedule)
 }
 
 func TestUpdateSchedule(t *testing.T) {
@@ -279,7 +279,7 @@ func TestUpdateSchedule(t *testing.T) {
 
 	schedule, err := c.UpdateSchedule("test-job", &expectedSchedule)
 	require.NoError(t, err)
-	require.Equal(t, &expectedSchedule, schedule)
+	assert.Equal(t, &expectedSchedule, schedule)
 }
 
 func TestRemoveSchedule(t *testing.T) {
@@ -312,12 +312,12 @@ func TestQueued(t *testing.T) {
 
 	q1, err := c.Queued("")
 	require.NoError(t, err)
-	require.Equal(t, expectedQueues, q1)
+	assert.Equal(t, expectedQueues, q1)
 
 	q2, err := c.Queued("test-job")
 	require.NoError(t, err)
-	require.Equal(t, expectedQueues, q2)
+	assert.Equal(t, expectedQueues, q2)
 
 	_, err = c.Queued("not-existing-job")
-	require.Errorf(t, err, `job "not-existing-job" does not exist`)
+	assert.Errorf(t, err, `job "not-existing-job" does not exist`)
 }

--- a/pkg/networking/client_test.go
+++ b/pkg/networking/client_test.go
@@ -33,5 +33,5 @@ func TestNodes(t *testing.T) {
 
 	nodes, err := c.Nodes()
 	require.NoError(t, err)
-	require.Equal(t, expectedNodes, nodes)
+	assert.Equal(t, expectedNodes, nodes)
 }


### PR DESCRIPTION
This backports the following commits to 2.0-patch.x and adjusts the CHANGELOG for 2.0-patch.4:

- https://github.com/dcos/dcos-core-cli/commit/63c8a319b96ae09f6c29c0a05137e3ee68ed6f45
- https://github.com/dcos/dcos-core-cli/commit/81228ed491060229a21c22caf00e23491b302ca7
- https://github.com/dcos/dcos-core-cli/commit/393ea1262c589a13489590421c6953bf540d5f3f