### PR TITLE
Fix `dcos node ssh` adding a trailing quote

### DIFF
--- a/python/lib/dcos/dcos/ssh_util.py
+++ b/python/lib/dcos/dcos/ssh_util.py
@@ -95,7 +95,7 @@ def get_ssh_proxy_options(ssh_options, user_options='',
             "Please run `ssh-agent`, then add your private key with "
             "`ssh-add`.")
 
-    proxy_options = '-A -t {0} {1} {2} -- \"ssh'.format(
+    proxy_options = '-A -t {0} {1} {2} -- ssh'.format(
         ssh_options, user_options, proxy_ip)
     return proxy_options
 

--- a/python/lib/dcoscli/dcoscli/node/main.py
+++ b/python/lib/dcoscli/dcoscli/node/main.py
@@ -927,11 +927,8 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
     if command is None:
         command = ''
 
-    ssh_options = ssh_util.get_ssh_options(
-        config_file, option, user, proxy_ip, master_proxy)
-    cmd = "ssh {0} {1} -- '{2}'".format(ssh_options, host, command)
-    if ssh_options != '':
-        cmd = cmd + "\""
+    cmd = _get_ssh_command(config_file, option, user, proxy_ip, master_proxy,
+                           host, command)
 
     emitter.publish(DefaultError("Running `{}`".format(cmd)))
     if not master_proxy and not proxy_ip:
@@ -941,6 +938,14 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
                          "`--master-proxy` or `--proxy-ip`"))
 
     return subprocess.Subproc().call(cmd, shell=True)
+
+
+def _get_ssh_command(config_file, option, user, proxy_ip, master_proxy,
+                     host, command):
+    ssh_options = ssh_util.get_ssh_options(
+        config_file, option, user, proxy_ip, master_proxy)
+
+    return "ssh {0} {1} -- '{2}'".format(ssh_options, host, command)
 
 
 def _decommission(mesos_id):

--- a/python/lib/dcoscli/dcoscli/service/main.py
+++ b/python/lib/dcoscli/dcoscli/service/main.py
@@ -286,7 +286,7 @@ def _log_marathon(follow, lines, ssh_config_file, user):
         ssh_config_file,
         user=user,
         master_proxy=True)
-    cmd = "ssh {0} {1} -- journalctl {2}-u {3}\"".format(
+    cmd = "ssh {0} {1} -- journalctl {2}-u {3}".format(
         ssh_options,
         leader_ip,
         journalctl_args,


### PR DESCRIPTION
This partially reverts commit e3a9dbe8cb271537ba94f6ed6f1d81c313f0896d
and adds a test covering the original issue as well as COPS-5494.

https://jira.mesosphere.com/browse/COPS-5494.