### PR TITLE
Create random dir

### DIFF
--- a/ci/integration-tests-linux.groovy
+++ b/ci/integration-tests-linux.groovy
@@ -63,7 +63,7 @@ pipeline {
         }
 
         stage("Run integration tests") {
-            agent { label 'py36' }
+            agent { label 'py37' }
             steps {
                 unstash "dcos-${os}"
                 withEnv(["DCOS_TEST_URL=${master_ip}", "OS=${os}"]) {

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -12,7 +12,6 @@ cd python/lib/dcoscli
 source env/bin/activate
 wget -qO env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/${OS}/x86-64/master/dcos
 chmod +x env/bin/dcos
-dcos cluster remove --all
 dcos cluster setup --no-check ${DCOS_TEST_URL}
 dcos plugin add -u ../../../build/$OS/dcos-core-cli.zip
 py.test -vv -x --durations=10 -p no:cacheprovider tests/integrations

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -4,6 +4,7 @@ export PYTHONIOENCODING=utf-8
 export CLI_TEST_SSH_USER=centos
 export CLI_TEST_MASTER_PROXY=1
 export PYTHON=python3.7
+export DCOS_DIR=$(mktemp)
 make plugin
 cd python/lib/dcoscli
 source env/bin/activate
@@ -13,3 +14,4 @@ dcos cluster remove --all
 dcos cluster setup --no-check ${DCOS_TEST_URL}
 dcos plugin add -u ../../../build/$OS/dcos-core-cli.zip
 py.test -vv -x --durations=10 -p no:cacheprovider tests/integrations
+rm -rf $DCOS_DIR

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -3,7 +3,8 @@ set -x
 export PYTHONIOENCODING=utf-8
 export CLI_TEST_SSH_USER=centos
 export CLI_TEST_MASTER_PROXY=1
-DCOS_EXPERIMENTAL=1 make plugin
+export PYTHON=python3.7
+make plugin
 cd python/lib/dcoscli
 source env/bin/activate
 wget -qO env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/${OS}/x86-64/master/dcos


### PR DESCRIPTION
We have a lots of failures due to unknown flag error. This might be result of concurrent builds on Mac that interfere withe each other. To prevent this we should use temp directory for dcos instead of default `~/.dcos`.