### PR TITLE
Make the integration tests script fail on test failures

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -6,7 +6,7 @@ set -ex
 export PYTHONIOENCODING=utf-8
 export CLI_TEST_SSH_USER=centos
 export CLI_TEST_MASTER_PROXY=1
-export DCOS_DIR=$(mktemp -d)
+export DCOS_DIR=$(mktemp -d /tmp/dcos.XXXXXXXXXX)
 export PYTHON=python3.7
 export LANG=en_US.utf-8
 export LC_ALL=en_US.utf-8

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -x
+
+set -ex
+
 export PYTHONIOENCODING=utf-8
 export CLI_TEST_SSH_USER=centos
 export CLI_TEST_MASTER_PROXY=1

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -2,19 +2,28 @@
 
 set -ex
 
+# prepare environment
 export PYTHONIOENCODING=utf-8
 export CLI_TEST_SSH_USER=centos
 export CLI_TEST_MASTER_PROXY=1
-export DCOS_DIR=$(mktemp)
+export DCOS_DIR=$(mktemp -d)
 export PYTHON=python3.7
 export LANG=en_US.utf-8
 export LC_ALL=en_US.utf-8
+
+# build the plugin
 make plugin
 cd python/lib/dcoscli
 source env/bin/activate
+
+# connect to cluster and install built plugin
 wget -qO env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/${OS}/x86-64/master/dcos
 chmod +x env/bin/dcos
 dcos cluster setup --no-check ${DCOS_TEST_URL}
 dcos plugin add -u ../../../build/$OS/dcos-core-cli.zip
+
+# run the tests
 py.test -vv -x --durations=10 -p no:cacheprovider tests/integrations
+
+# clean up locally (cluster is left for cloudcleaner to clean up)
 rm -rf $DCOS_DIR


### PR DESCRIPTION
The script needs to fail as soon as any command in the steps fails. That's what `set -e` does.

I also added some comments to the script and fixed the `mktemp` call.