### PR TITLE
Make local installed apps override Cosmos Apps

### DIFF
--- a/pkg/cmd/pkg/package_list.go
+++ b/pkg/cmd/pkg/package_list.go
@@ -78,7 +78,10 @@ func listPackages(ctx api.Context, opts listOptions, c cosmos.Client) error {
 		}
 
 		for _, pkg := range cosmosPackages {
-			packages[pkg.Name] = pkg
+			_, ok := packages[pkg.Name]
+			if !ok {
+				packages[pkg.Name] = pkg
+			}
 		}
 	}
 

--- a/pkg/cmd/pkg/package_list_test.go
+++ b/pkg/cmd/pkg/package_list_test.go
@@ -61,69 +61,63 @@ func TestListPackages(t *testing.T) {
 `, out.String())
 }
 
+var abPackage = cosmos.Package{
+	Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1",
+}
+var xyzPackage = cosmos.Package{
+	Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1",
+}
+var cliApp = cosmos.Package{
+	Apps: []string{"/cli-app"}, Command: &dcos.CosmosPackageCommand{Name: "cli-app"}, Description: "Some CLI APP",
+	Framework: true, Name: "cli-app", Selected: true, Version: "alpha",
+}
+var pkgCli = cosmos.Package{
+	Apps: []string{"/pkg-cli"}, Command: &dcos.CosmosPackageCommand{Name: "pkg-cli"}, Description: "Some CLI Package",
+	Framework: true, Name: "pkg-cli", Selected: true, Version: "2.4.4-1.15.4",
+}
+var mockPackages = []cosmos.Package{abPackage, xyzPackage}
 var testCases = []struct {
-	cluster string
-	options listOptions
-	out     []cosmos.Package
+	cluster        string
+	options        listOptions
+	cosmosResposne []cosmos.Package
+	out            []cosmos.Package
 }{
-	{NoPlugins, listOptions{jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"},
-		{Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1"}}},
-	{NoPlugins, listOptions{query: "package-2", jsonOutput: true}, []cosmos.Package{
-		{Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1"}}},
-	{NoPlugins, listOptions{query: "-2", jsonOutput: true}, []cosmos.Package{
-		{Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1"}}},
-	{NoPlugins, listOptions{query: "package", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"},
-		{Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1"}}},
-	{NoPlugins, listOptions{query: "a", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"},
-		{Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1"}}},
-	{NoPlugins, listOptions{query: "some-app", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"}}},
-	{NoPlugins, listOptions{appID: "some-app", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"}}},
-	{NoPlugins, listOptions{appID: "a", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"}}},
-	{NoPlugins, listOptions{appID: "b", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"}}},
-	{NoPlugins, listOptions{appID: "package-2", jsonOutput: true}, []cosmos.Package{
-		{Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Name: "package-2", Version: "0.0.1"}}},
-	{NoPlugins, listOptions{cliOnly: true, jsonOutput: true}, []cosmos.Package{}},
-	{NoPlugins, listOptions{appID: "not found", jsonOutput: true}, []cosmos.Package{}},
-	{NoPlugins, listOptions{query: "not found", jsonOutput: true}, []cosmos.Package{}},
-	{MultipleCommands, listOptions{cliOnly: true, jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"/cli-app"}, Command: &dcos.CosmosPackageCommand{Name: "cli-app"}, Description: "Some CLI APP",
-			Framework: true, Name: "cli-app", Selected: true, Version: "alpha"},
-		{Apps: []string{"/pkg-cli"}, Command: &dcos.CosmosPackageCommand{Name: "pkg-cli"}, Description: "Some CLI Package",
-			Framework: true, Name: "pkg-cli", Selected: true, Version: "2.4.4-1.15.4"}}},
-	{MultipleCommands, listOptions{query: "cli", cliOnly: true, jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"/cli-app"}, Command: &dcos.CosmosPackageCommand{Name: "cli-app"}, Description: "Some CLI APP",
-			Framework: true, Name: "cli-app", Selected: true, Version: "alpha"},
-		{Apps: []string{"/pkg-cli"}, Command: &dcos.CosmosPackageCommand{Name: "pkg-cli"}, Description: "Some CLI Package",
-			Framework: true, Name: "pkg-cli", Selected: true, Version: "2.4.4-1.15.4"}}},
-	{MultipleCommands, listOptions{query: "app", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"/cli-app"}, Command: &dcos.CosmosPackageCommand{Name: "cli-app"}, Description: "Some CLI APP",
-			Framework: true, Name: "cli-app", Selected: true, Version: "alpha"},
-		{Apps: []string{"a", "b", "some-app"}, Description: "package-2", Name: "package-1", Version: "0.0.0.1"}}},
-	{MultipleCommands, listOptions{appID: "app", jsonOutput: true}, []cosmos.Package{}},
-	{MultipleCommands, listOptions{query: "package", cliOnly: true, jsonOutput: true}, []cosmos.Package{}},
-	{MultipleCommands, listOptions{appID: "cli-app", jsonOutput: true}, []cosmos.Package{
-		{Apps: []string{"/cli-app"}, Command: &dcos.CosmosPackageCommand{Name: "cli-app"}, Description: "Some CLI APP",
-			Framework: true, Name: "cli-app", Selected: true, Version: "alpha"}}},
+	{NoPlugins, listOptions{jsonOutput: true}, mockPackages, mockPackages},
+	{NoPlugins, listOptions{query: "package-2", jsonOutput: true}, mockPackages, []cosmos.Package{xyzPackage}},
+	{NoPlugins, listOptions{query: "-2", jsonOutput: true}, mockPackages, []cosmos.Package{xyzPackage}},
+	{NoPlugins, listOptions{query: "package", jsonOutput: true}, mockPackages, mockPackages},
+	{NoPlugins, listOptions{query: "a", jsonOutput: true}, mockPackages, mockPackages},
+	{NoPlugins, listOptions{query: "some-app", jsonOutput: true}, mockPackages, []cosmos.Package{abPackage}},
+	{NoPlugins, listOptions{appID: "some-app", jsonOutput: true}, mockPackages, []cosmos.Package{abPackage}},
+	{NoPlugins, listOptions{appID: "a", jsonOutput: true}, mockPackages, []cosmos.Package{abPackage}},
+	{NoPlugins, listOptions{appID: "b", jsonOutput: true}, mockPackages, []cosmos.Package{abPackage}},
+	{NoPlugins, listOptions{appID: "package-2", jsonOutput: true}, mockPackages,
+		[]cosmos.Package{xyzPackage}},
+	{NoPlugins, listOptions{cliOnly: true, jsonOutput: true}, mockPackages, []cosmos.Package{}},
+	{NoPlugins, listOptions{appID: "not found", jsonOutput: true}, mockPackages, []cosmos.Package{}},
+	{NoPlugins, listOptions{query: "not found", jsonOutput: true}, mockPackages, []cosmos.Package{}},
+	{MultipleCommands, listOptions{cliOnly: true, jsonOutput: true}, mockPackages, []cosmos.Package{cliApp, pkgCli}},
+	{MultipleCommands, listOptions{query: "cli", cliOnly: true, jsonOutput: true}, mockPackages, []cosmos.Package{cliApp, pkgCli}},
+	{MultipleCommands, listOptions{query: "app", jsonOutput: true}, mockPackages, []cosmos.Package{cliApp, abPackage}},
+	{MultipleCommands, listOptions{appID: "app", jsonOutput: true}, mockPackages, []cosmos.Package{}},
+	{MultipleCommands, listOptions{query: "package", cliOnly: true, jsonOutput: true}, mockPackages, []cosmos.Package{}},
+	{MultipleCommands, listOptions{appID: "cli-app", jsonOutput: true}, mockPackages, []cosmos.Package{cliApp}},
+	{MultipleCommands, listOptions{jsonOutput: true}, []cosmos.Package{
+		{Name: "cli-app", Apps: []string{"not", "a", "cliApp"}, Description: "package-2", Version: "0.0.0.1"},
+		{Name: "pkg-cli", Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Version: "0.0.1"},
+	}, []cosmos.Package{cliApp, pkgCli}},
+	{MultipleCommands, listOptions{jsonOutput: true, cliOnly: true}, []cosmos.Package{
+		{Name: "cli-app", Apps: []string{"not", "a", "cliApp"}, Description: "package-2", Version: "0.0.0.1"},
+		{Name: "pkg-cli", Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Version: "0.0.1"},
+	}, []cosmos.Package{cliApp, pkgCli}},
 }
 
 func TestListPackagesFilterJson(t *testing.T) {
-	client := &mocks.Client{}
-	packages := []cosmos.Package{
-		{Name: "package-1", Apps: []string{"a", "b", "some-app"}, Description: "package-2", Version: "0.0.0.1"},
-		{Name: "package-2", Command: &dcos.CosmosPackageCommand{Name: "xyz"}, Description: "XYZ", Version: "0.0.1"},
-	}
-	client.On("PackageList").Return(packages, nil)
-
 	for _, tt := range testCases {
 		t.Run(fmt.Sprintf("%s_%#v", tt.cluster, tt.options), func(t *testing.T) {
 			out, ctx := setupCluster(tt.cluster)
+			client := &mocks.Client{}
+			client.On("PackageList").Return(tt.cosmosResposne, nil)
 
 			err := listPackages(ctx, tt.options, client)
 			assert.NoError(t, err)

--- a/python/lib/dcoscli/tests/data/package/json/test_list_helloworld.json
+++ b/python/lib/dcoscli/tests/data/package/json/test_list_helloworld.json
@@ -6,9 +6,27 @@
     "command": {
       "name": "helloworld"
     },
+    "config": {
+      "$schema": "http://json-schema.org/schema#",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "default": "helloworld",
+          "type": "string"
+        },
+        "port": {
+          "default": 8080,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "description": "Example DCOS application package",
     "framework": false,
     "maintainer": "support@mesosphere.io",
+    "marathon": {
+      "v2AppMustacheTemplate": "ewogICJpZCI6ICJ7e25hbWV9fSIsCiAgImNwdXMiOiAxLjAsCiAgIm1lbSI6IDUxMiwKICAiaW5zdGFuY2VzIjogMSwKICAiY21kIjogInB5dGhvbjMgLW0gaHR0cC5zZXJ2ZXIge3twb3J0fX0iLAogICJjb250YWluZXIiOiB7CiAgICAidHlwZSI6ICJET0NLRVIiLAogICAgImRvY2tlciI6IHsKICAgICAgImltYWdlIjogInB5dGhvbjozIiwKICAgICAgIm5ldHdvcmsiOiAiSE9TVCIKICAgIH0KICB9Cn0K"
+    },
     "name": "helloworld",
     "packagingVersion": "3.0",
     "postInstallNotes": "A sample post-installation message",


### PR DESCRIPTION
`dcos package --json` and `dcos package --cli --json` may results in different responses. To keep backward compatibility we need to make locally installed packages overrides cosmos response.

This happens only for packages that has cli and app.

**Backports:** https://github.com/dcos/dcos-core-cli/pull/396
**Reverts:** https://github.com/dcos/dcos-core-cli/pull/389/commits/5cb304b532da5b22b40d21bcb9716c60bf24f9e1
**Fixes:** https://jira.mesosphere.com/browse/DCOS_OSS-5657