### PR TITLE
Fix deprecations

### DIFF
--- a/python/lib/dcos/dcos/jsonitem.py
+++ b/python/lib/dcos/dcos/jsonitem.py
@@ -272,7 +272,7 @@ def _parse_url(value):
     scheme_pattern = r'^(?P<scheme>(?:(?:https?)://))'
     domain_pattern = (
         r'(?P<hostname>(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.?)+'
-        '(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)?|')  # domain,
+        r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)?|')  # domain,
 
     value_regex = re.match(
         scheme_pattern +  # http:// or https://

--- a/python/lib/dcos/dcos/util.py
+++ b/python/lib/dcos/dcos/util.py
@@ -452,8 +452,8 @@ def _hack_error_message_fix(message):
     # This regular expression matches the character 'u' followed by the
     # single-quote character, all optionally preceded by a left square
     # bracket, parenthesis, curly brace, or whitespace character.
-    return re.compile("([\[\(\{\s])u'").sub(
-        "\g<1>'",
+    return re.compile(r"([\[\(\{\s])u'").sub(
+        r"\g<1>'",
         re.compile("^u'").sub("'", message))
 
 

--- a/python/lib/dcoscli/dcoscli/test/marathon.py
+++ b/python/lib/dcoscli/dcoscli/test/marathon.py
@@ -19,7 +19,7 @@ def add_app(app_path, wait=True):
     cmd = ['dcos', 'marathon', 'app', 'add', app_path]
     returncode, stdout, stderr = exec_command(cmd)
     assert returncode == 0
-    assert re.fullmatch('Created deployment \S+\n', stdout.decode('utf-8'))
+    assert re.fullmatch(r'Created deployment \S+\n', stdout.decode('utf-8'))
     assert stderr == b''
 
     if wait:
@@ -173,7 +173,7 @@ def add_pod(pod_path, wait=True):
     cmd = ['dcos', 'marathon', 'pod', 'add', pod_path]
     returncode, stdout, stderr = exec_command(cmd)
     assert returncode == 0
-    assert re.fullmatch('Created deployment \S+\n', stdout.decode('utf-8'))
+    assert re.fullmatch(r'Created deployment \S+\n', stdout.decode('utf-8'))
     assert stderr == b''
 
     if wait:
@@ -276,7 +276,7 @@ def add_group(group_path, wait=True):
     cmd = ['dcos', 'marathon', 'group', 'add', group_path]
     returncode, stdout, stderr = exec_command(cmd)
     assert returncode == 0
-    assert re.fullmatch('Created deployment \S+\n', stdout.decode('utf-8'))
+    assert re.fullmatch(r'Created deployment \S+\n', stdout.decode('utf-8'))
     assert stderr == b''
 
     if wait:

--- a/python/lib/dcoscli/tests/integrations/test_marathon_debug.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon_debug.py
@@ -6,8 +6,8 @@ import retrying
 from dcoscli.test.common import exec_command
 from dcoscli.test.marathon import app, pod, watch_for_overdue
 
-list_regex = '/stuck-(?:sleep|pod)\W+[^Z]+Z\W+\d\W+(?:True|False)' \
-             '\W+\d{1,2}\W+\d{1,2}\W+[^Z]+Z\W+[^Z]+Z'
+list_regex = r'/stuck-(?:sleep|pod)\W+[^Z]+Z\W+\d\W+(?:True|False)' \
+             r'\W+\d{1,2}\W+\d{1,2}\W+[^Z]+Z\W+[^Z]+Z'
 
 
 def test_debug_list():

--- a/python/lib/dcoscli/tests/integrations/test_marathon_groups.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon_groups.py
@@ -119,7 +119,7 @@ def _add_group_by_stdin(file_path):
         cmd = ['dcos', 'marathon', 'group', 'add']
         returncode, stdout, stderr = exec_command(cmd, stdin=fd)
         assert returncode == 0
-        assert re.fullmatch('Created deployment \S+\n',
+        assert re.fullmatch(r'Created deployment \S+\n',
                             stdout.decode('utf-8'))
         assert stderr == b''
 

--- a/python/lib/dcoscli/tests/integrations/test_marathon_pod.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon_pod.py
@@ -87,7 +87,7 @@ def _pod_add_from_stdin(file_path):
         returncode, stdout, stderr = exec_command(cmd, stdin=fd)
 
     assert returncode == 0
-    assert re.fullmatch('Created deployment \S+\n', stdout.decode('utf-8'))
+    assert re.fullmatch(r'Created deployment \S+\n', stdout.decode('utf-8'))
     assert stderr == b''
 
     watch_all_deployments()
@@ -147,7 +147,7 @@ def _assert_pod_update_from_stdin(extra_args, pod_json_file_path):
         returncode, stdout, stderr = exec_command(cmd, stdin=fd)
 
     assert returncode == 0
-    assert re.fullmatch('Created deployment \S+\n', stdout.decode('utf-8'))
+    assert re.fullmatch(r'Created deployment \S+\n', stdout.decode('utf-8'))
     assert stderr == b''
 
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -19,7 +19,7 @@ source env/bin/activate
 # connect to cluster and install built plugin
 wget -qO env/bin/dcos https://downloads.dcos.io/cli/testing/binaries/dcos/${OS}/x86-64/master/dcos
 chmod +x env/bin/dcos
-dcos cluster setup --no-check ${DCOS_TEST_URL}
+dcos cluster setup --no-check ${DCOS_TEST_URL} 2> /dev/null
 dcos plugin add -u ../../../build/$OS/dcos-core-cli.zip
 
 # run the tests


### PR DESCRIPTION
In order to fix depredations we need to mark strings as raw (prefix them with `r`).