### PR TITLE
Cleanup tests

### DIFF
--- a/pkg/cmd/marathon/app/app_kill_test.go
+++ b/pkg/cmd/marathon/app/app_kill_test.go
@@ -1,15 +1,12 @@
 package app
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dcos/dcos-cli/pkg/config"
-	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/dcos/dcos-core-cli/pkg/marathon"
 	goMarathon "github.com/gambol99/go-marathon"
 	"github.com/stretchr/testify/assert"
@@ -24,13 +21,7 @@ func TestMarathonKill(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -50,13 +41,7 @@ func TestMarathonKillHost(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -76,11 +61,7 @@ func TestMarathonKillMissingApp(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -105,13 +86,7 @@ func TestMarathonKillScale(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -133,11 +108,7 @@ func TestMarathonKillScaleMissingApp(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)

--- a/pkg/cmd/marathon/app/app_list_test.go
+++ b/pkg/cmd/marathon/app/app_list_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dcos/dcos-cli/pkg/config"
-	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/dcos/dcos-core-cli/pkg/marathon"
 	m "github.com/gambol99/go-marathon"
 	"github.com/stretchr/testify/assert"
@@ -43,13 +41,7 @@ func TestAppList(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	require.NoError(t, err)
@@ -80,13 +72,7 @@ func TestAppListQuiet(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	require.NoError(t, err)
@@ -116,13 +102,7 @@ func TestAppListJSON(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	require.NoError(t, err)

--- a/pkg/cmd/marathon/app/app_remove_test.go
+++ b/pkg/cmd/marathon/app/app_remove_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dcos/dcos-cli/pkg/config"
-	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/dcos/dcos-core-cli/pkg/marathon"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,11 +17,7 @@ func TestMarathonRemove(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -40,11 +34,7 @@ func TestMarathonRemoveForce(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -61,11 +51,7 @@ func TestMarathonRemoveMissingApp(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -83,11 +69,7 @@ func TestMarathonRemoveOtherError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)

--- a/pkg/cmd/marathon/app/app_show_test.go
+++ b/pkg/cmd/marathon/app/app_show_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dcos/dcos-cli/pkg/config"
-	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/gambol99/go-marathon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,13 +29,7 @@ func TestAppShowNoVersion(t *testing.T) {
 		}
 	}))
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	err := appShow(ctx, "/kafka", "")
 	require.NoError(t, err)
@@ -75,13 +67,7 @@ func TestAppShowRelativeVersion(t *testing.T) {
 		}
 	}))
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	err := appShow(ctx, "/kafka", "-2")
 	require.NoError(t, err)
@@ -102,13 +88,7 @@ func TestAppShowRelativePostiveVersion(t *testing.T) {
 		assert.Fail(t, "no calls to DCOS expected")
 	}))
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	err := appShow(ctx, "/kafka", "2")
 	assert.EqualError(t, err, "relative versions must be negative: 2")
@@ -137,13 +117,7 @@ func TestAppShowAbsoluteVersion(t *testing.T) {
 		}
 	}))
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, out := newContext(ts)
 
 	err := appShow(ctx, "/kafka", "2019-11-18T07:12:44.466Z")
 	require.NoError(t, err)
@@ -177,13 +151,7 @@ func TestAppShowNonExistantVersion(t *testing.T) {
 		}
 	}))
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	err := appShow(ctx, "/kafka", "2019-11-15T07:12:44.466Z")
 	assert.EqualError(t, err, "app '/kafka' does not exist")

--- a/pkg/cmd/marathon/app/app_version_list_test.go
+++ b/pkg/cmd/marathon/app/app_version_list_test.go
@@ -1,13 +1,10 @@
 package app
 
 import (
-	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dcos/dcos-cli/pkg/config"
-	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/dcos/dcos-core-cli/pkg/marathon"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,13 +17,7 @@ func TestMarathonAppVersionList(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -44,13 +35,7 @@ func TestMarathonAppVersionListMaxCount(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -68,13 +53,7 @@ func TestMarathonAppVersionListMaxCountTooBig(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -93,13 +72,7 @@ func TestMarathonAppVersionListError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	out := new(bytes.Buffer)
-	env := mock.NewEnvironment()
-	env.Out = out
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx, _ := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)

--- a/pkg/cmd/marathon/marathon_about_test.go
+++ b/pkg/cmd/marathon/marathon_about_test.go
@@ -19,11 +19,7 @@ func TestMarathonAbout(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -41,15 +37,20 @@ func TestMarathonAboutClientError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
 
 	err = marathonAbout(ctx, *client)
 	assert.EqualError(t, err, `HTTP 500 error`)
+}
+
+func newContext(ts *httptest.Server) *mock.Context {
+	env := mock.NewEnvironment()
+	ctx := mock.NewContext(env)
+	cluster := config.NewCluster(nil)
+	cluster.SetURL(ts.URL)
+	ctx.SetCluster(cluster)
+	return ctx
 }

--- a/pkg/cmd/marathon/marathon_ping_test.go
+++ b/pkg/cmd/marathon/marathon_ping_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dcos/dcos-cli/pkg/config"
-	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/dcos/dcos-core-cli/pkg/marathon"
 	"github.com/dcos/dcos-core-cli/pkg/mesos"
 	"github.com/stretchr/testify/assert"
@@ -21,11 +19,7 @@ func TestMarathonPingOnce(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -49,11 +43,7 @@ func TestMarathonPing(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)
@@ -84,11 +74,7 @@ func TestMarathonPingError(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	ctx.SetCluster(cluster)
+	ctx := newContext(ts)
 
 	client, err := marathon.NewClient(ctx)
 	assert.NoError(t, err)


### PR DESCRIPTION
Use `newContext` function instead of copying same code in every test.

Refs: https://github.com/dcos/dcos-core-cli/pull/417#discussion_r350699733