### PR TITLE
feat(calicoctl): add calicoctl wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ darwin linux windows: docker-image
 	$(call inDocker, GOOS=$(@) go build \
 		-tags '$(GO_BUILD_TAGS)' \
 		-o build/$(@)/dcos$($(@)_EXE) ./cmd/dcos)
+	@mkdir -p build/$(@)/plugin/bin
+	$(call inDocker, curl -L https://downloads.mesosphere.io/dcos-calicoctl/bin/v3.12.0-d2iq.1/fd5d699-b80546e/calicoctl-$(@)-amd64$($(@)_EXE) --output build/$(@)/plugin/bin/calicoctl$($(@)_EXE) && chmod +x build/$(@)/plugin/bin/calicoctl$($(@)_EXE))
 
 .PHONY: install
 install:

--- a/pkg/cmd/calico/calico.go
+++ b/pkg/cmd/calico/calico.go
@@ -1,0 +1,219 @@
+package calico
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/dcos"
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-core-cli/pkg/mesos"
+	"github.com/dcos/dcos-core-cli/pkg/networking"
+	"github.com/spf13/cobra"
+)
+
+type stateResult struct {
+	state *mesos.State
+	err   error
+}
+
+type execContext = func(name string, arg ...string) *exec.Cmd
+
+func runCalicoCtl(cmdContext execContext, args []string, ctx api.Context, env []string) ([]byte, error) {
+	var command *exec.Cmd
+
+	cluster, _ := ctx.Cluster()
+	basePath := cluster.Dir()
+	calicoCtl := path.Join(basePath, "subcommands/dcos-core-cli/env/bin", "calicoctl")
+	if len(args) == 0 {
+		command = cmdContext(calicoCtl, "--help")
+	} else {
+		command = cmdContext(calicoCtl, args...)
+	}
+	command.Env = append(command.Env, append(os.Environ(), env...)...)
+	return command.CombinedOutput()
+}
+
+func request(url string) (*http.Response, error) {
+
+	probeClient := httpclient.New(strings.Replace(url, "https", "http", 1) + ":12379")
+
+	return probeClient.Get("")
+}
+
+func getMesosState(ctx api.Context) chan stateResult {
+	client, _ := mesosClient(ctx)
+	stateRes := make(chan stateResult)
+	go func() {
+		state, err := client.State()
+		stateRes <- stateResult{state, err}
+	}()
+	return stateRes
+}
+
+func getIps(ctx api.Context) chan map[string][]string {
+	cluster, _ := ctx.Cluster()
+	httpClient, _ := ctx.HTTPClient(cluster, httpclient.Timeout(3*time.Second))
+
+	ipsRes := make(chan map[string][]string)
+	// Ips Start
+	go func() {
+		ips := make(map[string][]string)
+		c := networking.NewClient(httpClient)
+		nodes, err := c.Nodes()
+		if err != nil {
+			ctx.Logger().Debug(err)
+		} else {
+			for _, node := range nodes {
+				ips[node.PrivateIP] = node.PublicIPs
+			}
+		}
+		ipsRes <- ips
+	}()
+	return ipsRes
+}
+
+func getEnvironment(ctx api.Context) []string {
+	var environmentVariables []string
+
+	cluster, err := ctx.Cluster()
+	if err != nil {
+		ctx.Logger().Debug(err)
+	}
+
+	httpClient, err := ctx.HTTPClient(cluster, httpclient.Timeout(3*time.Second))
+	dcosClient := dcos.NewClient(httpClient)
+
+	//State  start
+	stateRes := getMesosState(ctx)
+	// State End
+
+	ipsRes := getIps(ctx)
+
+	url := cluster.URL()
+	_, err = request(url)
+	if err != nil {
+		// Check out state start
+		stateResult := <-stateRes
+		if stateResult.err != nil {
+			ctx.Logger().Debug(stateResult.err)
+		}
+		state := stateResult.state
+		// Check out state end
+		ips := <-ipsRes
+		// master ip start
+		masterIPRes := make(chan string)
+		go func() {
+			if mesosMasters, err := mesos.NewClient(httpClient).Masters(); err == nil {
+				for _, master := range mesosMasters {
+					if master.IP == state.Hostname {
+						masterIPRes <- ips[master.IP][0]
+					}
+				}
+			} else {
+				ctx.Logger().Debug(err)
+
+			}
+		}()
+		masterIP := <-masterIPRes
+		url = "https://" + masterIP
+		_, err = request(url)
+		if err != nil {
+			ctx.Logger().Debug("Calicoctl is not able to connect to the gRPC port.")
+		}
+	}
+
+	if dcosVersion, err := dcosClient.Version(); err != nil {
+		ctx.Logger().Debug(err)
+	} else {
+		if dcosVersion.DCOSVariant != "enterprise" {
+			// master ip end
+			environmentVariables = append(
+				os.Environ(),
+				fmt.Sprintf("ETCD_CUSTOM_GRPC_METADATA=authorization:token=%s", cluster.ACSToken()),
+				fmt.Sprintf("ETCD_ENDPOINTS=%s:12379", url),
+			)
+			return environmentVariables
+		}
+	}
+
+	caFilePathRes := make(chan string)
+	go func() {
+		caClient := NewClient(httpClient)
+		cacert, caerr := caClient.getCaCertificate()
+
+		if caerr != nil {
+			ctx.Logger().Debug(caerr)
+		}
+
+		caFilePath := path.Join(cluster.Dir(), "dcos-ca.crt")
+		out, fileErr := os.Create(caFilePath)
+		if fileErr != nil {
+			ctx.Logger().Debug(fileErr)
+		}
+		out.WriteString(cacert)
+		out.Close()
+		if err != nil {
+			ctx.Logger().Debug(err)
+		}
+		caFilePathRes <- caFilePath
+	}()
+
+	caFilePath := <-caFilePathRes
+
+	environmentVariables = append(
+		os.Environ(),
+		fmt.Sprintf("ETCD_CUSTOM_GRPC_METADATA=authorization:token=%s", cluster.ACSToken()),
+		fmt.Sprintf("ETCD_ENDPOINTS=%s:12379", url),
+		fmt.Sprintf("ETCD_CA_CERT_FILE=%s", caFilePath),
+	)
+
+	return environmentVariables
+}
+
+// NewCommand creates the `dcos package` subcommand.
+func NewCommand(ctx api.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "calico [command]",
+		Short: "Calicoctl wrapper",
+		Run: func(cmd *cobra.Command, args []string) {
+			out, err := runCalicoCtl(exec.Command, args, ctx, getEnvironment(ctx))
+			fmt.Print(string(out))
+			if err != nil {
+				ctx.Logger().Debug(err)
+				fmt.Println(calicoError())
+			}
+
+		},
+	}
+
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		out, err := runCalicoCtl(exec.Command, args[1:], ctx, getEnvironment(ctx))
+		fmt.Print(string(out))
+		if err != nil {
+			ctx.Logger().Debug(err)
+			fmt.Println(calicoError())
+		}
+	})
+
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		out, err := runCalicoCtl(exec.Command, os.Args[2:], ctx, getEnvironment(ctx))
+		fmt.Print(string(out))
+		if err != nil {
+			ctx.Logger().Debug(err)
+			fmt.Println(calicoError())
+		}
+		return nil
+	})
+
+	return cmd
+}
+
+func calicoError() string {
+	return "CalicoCtl exited with an error"
+}

--- a/pkg/cmd/calico/calico_client.go
+++ b/pkg/cmd/calico/calico_client.go
@@ -1,0 +1,63 @@
+package calico
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-core-cli/pkg/mesos"
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+)
+
+// Client is a calico client for DC/OS.
+type Client struct {
+	http *httpclient.Client
+}
+
+// NewClient creates a new calico client.
+func NewClient(baseClient *httpclient.Client) *Client {
+	return &Client{
+		http: baseClient,
+	}
+}
+
+// getCaCertificate gets the CA certificate from the server.
+func (c *Client) getCaCertificate() (string, error) {
+	resp, err := c.http.Get("/ca/dcos-ca.crt")
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case 200:
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		return buf.String(), nil
+	default:
+		return "", httpResponseToError(resp)
+	}
+}
+
+func httpResponseToError(resp *http.Response) error {
+	if resp.StatusCode < 400 {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+	return &httpclient.HTTPError{
+		Response: resp,
+	}
+}
+
+func mesosClient(ctx api.Context) (*mesos.Client, error) {
+	cluster, err := ctx.Cluster()
+	if err != nil {
+		return nil, err
+	}
+	baseURL, _ := cluster.Config().Get("core.mesos_master_url").(string)
+	if baseURL == "" {
+		baseURL = cluster.URL() + "/mesos"
+	}
+	return mesos.NewClient(pluginutil.HTTPClient(baseURL)), nil
+}

--- a/pkg/cmd/calico/calico_test.go
+++ b/pkg/cmd/calico/calico_test.go
@@ -1,0 +1,117 @@
+package calico
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/dcos/dcos-cli/pkg/config"
+	"github.com/dcos/dcos-cli/pkg/mock"
+	"gotest.tools/assert"
+)
+
+func Test_getMesosState(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/mesos/master/state", r.URL.String())
+		assert.Equal(t, "GET", r.Method)
+		w.Write([]byte(`{"Hostname":"127.0.0.1"}`))
+	}))
+	defer ts.Close()
+	ctx := newContext(ts)
+
+	data := <-getMesosState(ctx)
+	assert.Equal(t, data.state.Hostname, "127.0.0.1")
+}
+
+func Test_getIps(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/net/v1/nodes", r.URL.String())
+		assert.Equal(t, "GET", r.Method)
+		w.Write([]byte(`[{
+      "updated": "2020-03-14T13:37:00.000Z",
+      "public_ips": [
+        "127.0.0.2"
+      ],
+      "private_ip": "127.0.0.1",
+      "hostname": "ip-172-0-0-1"
+    }]`))
+	}))
+	defer ts.Close()
+	ctx := newContext(ts)
+
+	data := <-getIps(ctx)
+	wanted := map[string][]string{"127.0.0.1": {"127.0.0.2"}}
+	assert.DeepEqual(t, data, wanted)
+}
+
+func newContext(ts *httptest.Server) *mock.Context {
+	env := mock.NewEnvironment()
+	ctx := mock.NewContext(env)
+	cluster := config.NewCluster(nil)
+	cluster.SetURL(ts.URL)
+	cluster.Config().SetPath("testDir/")
+	ctx.SetCluster(cluster)
+	return ctx
+}
+
+const (
+	testArg      = "--help"
+	testEnvValue = "GO_TEST_PROCESS_ENV=true"
+)
+
+func Test_runCalicoCtl(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer ts.Close()
+	ctx := newContext(ts)
+	stdout, err := runCalicoCtl(fakeExecCommandSuccess, []string{testArg}, ctx, []string{testEnvValue})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Check to make sure the stdout is returned properly
+	stdoutStr := string(stdout)
+	testOutput := fmt.Sprintf("%v | %v %v", testEnvValue, path.Join("testDir", "subcommands/dcos-core-cli/env/bin/calicoctl"), testArg)
+	if stdoutStr != testOutput {
+		t.Errorf("stdout mismatch:\n%s\n vs \n%s", stdoutStr, testOutput)
+	}
+
+}
+
+// TestShellProcessSuccess is a method that is called as a substitute for a shell command,
+// the GO_TEST_PROCESS flag ensures that if it is called as part of the test suite, it is
+// skipped.
+func TestShellProcessSuccess(t *testing.T) {
+	if os.Getenv("GO_TEST_PROCESS") != "1" {
+		return
+	}
+	// Print out the test value to stdout
+	var envValue string
+	env := os.Environ()
+	for _, v := range env {
+		if v == testEnvValue {
+			envValue = v
+		}
+	}
+	args := os.Args
+	fmt.Fprintf(os.Stdout, "%v | %v", envValue, strings.Join(args[len(args)-2:], " "))
+	os.Exit(0)
+}
+
+// fakeExecCommandSuccess is a function that initialises a new exec.Cmd, one which will
+// simply call TestShellProcessSuccess rather than the command it is provided. It will
+// also pass through the command and its arguments as an argument to TestShellProcessSuccess
+func fakeExecCommandSuccess(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestShellProcessSuccess", "--", command}
+	cs = append(cs, args...)
+	arg := os.Args[0]
+	cmd := exec.Command(arg, cs...)
+	cmd.Env = []string{"GO_TEST_PROCESS=1"}
+	return cmd
+}

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-core-cli/pkg/cmd/calico"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/diagnostics"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/job"
 	"github.com/dcos/dcos-core-cli/pkg/cmd/marathon"
@@ -21,6 +22,7 @@ func NewDCOSCommand(ctx api.Context) *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		calico.NewCommand(ctx),
 		job.NewCommand(ctx),
 		node.NewCommand(ctx),
 		pkg.NewCommand(ctx),

--- a/scripts/plugin/package_plugin.py
+++ b/scripts/plugin/package_plugin.py
@@ -12,6 +12,11 @@ schema_version = 1
 name = "dcos-core-cli"
 
 [[commands]]
+name = "calico"
+path = "bin/dcos{0}"
+description = "Manage Calico in DC/OS"
+
+[[commands]]
 name = "job"
 path = "bin/dcos{0}"
 description = "Deploy and manage jobs in DC/OS"


### PR DESCRIPTION
This adds a wrapper for calicoctl what still needs to be done:
- [x] add calicoctl download on build and bundle it with the plugin
- [x] fix permission passing to calicoctl
- [x] add probing
- [ ] add tests
- [x] add go routines and channels for the requests to improve performance of the calico command

to get this working you currently need to run 
```
curl -L https://github.com/projectcalico/calicoctl/releases/download/v3.12.0/calicoctl-darwin-amd64 --output build/darwin/calico.zip && unzip build/darwin/plugin/bin/calicoctl && chmod +x build/darwin/plugin/bin/calicoctl
```
 before  building the package.