### PR TITLE
Add JSON output to job run command

### DIFF
--- a/pkg/cmd/job/job_run.go
+++ b/pkg/cmd/job/job_run.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/dcos/dcos-cli/api"
@@ -9,6 +10,7 @@ import (
 
 // newCmdClusterRun runs a given job right now.
 func newCmdJobRun(ctx api.Context) *cobra.Command {
+	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:   "run <job-id>",
 		Short: "Run a job now",
@@ -23,9 +25,15 @@ func newCmdJobRun(ctx api.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if jsonOutput {
+				enc := json.NewEncoder(ctx.Out())
+				enc.SetIndent("", "    ")
+				return enc.Encode(run)
+			}
 			fmt.Fprintln(ctx.Out(), run.ID)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print in json format")
 	return cmd
 }

--- a/python/lib/dcoscli/tests/integrations/test_job.py
+++ b/python/lib/dcoscli/tests/integrations/test_job.py
@@ -185,6 +185,14 @@ def test_show_runs():
         assert 'pikachu' in stdout.decode('utf-8')
 
 
+def test_run_json():
+    with _no_schedule_instance_job():
+        returncode, stdout, stderr = exec_command(
+            ['dcos', 'job', 'run', '--json', 'pikachu'])
+        assert returncode == 0
+        assert '"jobId": "pikachu",' in stdout.decode('utf-8')
+
+
 def _run_job(job_id):
     returncode, stdout, stderr = exec_command(
         ['dcos', 'job', 'run', job_id])


### PR DESCRIPTION
Add missing --json flag to job run command.
This function was in Python code but was missing in Go.

Fixes: D2IQ-68975