### PR TITLE
Fix calico test to work with latest version (#465)

### DIFF
--- a/python/lib/dcoscli/tests/data/calico/version.txt
+++ b/python/lib/dcoscli/tests/data/calico/version.txt
@@ -1,4 +1,4 @@
 Client Version:    v3.12.0-d2iq.1
 Git commit:        fd5d699
-Cluster Version:   v3.8.2
+Cluster Version:   v3.14.0
 Cluster Type:      unknown


### PR DESCRIPTION
Updated version introduced in https://github.com/dcos/dcos/commit/a121c93f8c243609e63d7c2ef55ed3367e034641#diff-650981bd8300fc72a8c85f8fb0c26a5c
breaks the test so we need to update desired output.