### PR TITLE
Retry when launch AWS cluster fails.

### DIFF
--- a/ci/integration-tests-linux.groovy
+++ b/ci/integration-tests-linux.groovy
@@ -40,11 +40,13 @@ pipeline {
 
         stage("Launch AWS Cluster") {
             steps {
-                withCredentials(credentials) {
-                    script {
-                        master_ip = sh(script: 'cd scripts && ./launch_aws_cluster.sh', returnStdout: true).trim()
+                retry(5) {
+                    withCredentials(credentials) {
+                        script {
+                            master_ip = sh(script: 'cd scripts && ./launch_aws_cluster.sh', returnStdout: true).trim()
+                        }
+                        stash includes: 'scripts/**/*', name: 'terraform'
                     }
-                    stash includes: 'scripts/**/*', name: 'terraform'
                 }
             }
         }

--- a/ci/integration-tests-mac.groovy
+++ b/ci/integration-tests-mac.groovy
@@ -40,11 +40,13 @@ pipeline {
 
         stage("Launch AWS Cluster") {
             steps {
-                withCredentials(credentials) {
-                    script {
-                        master_ip = sh(script: 'cd scripts && ./launch_aws_cluster.sh', returnStdout: true).trim()
+                retry(5) {
+                    withCredentials(credentials) {
+                        script {
+                            master_ip = sh(script: 'cd scripts && ./launch_aws_cluster.sh', returnStdout: true).trim()
+                        }
+                        stash includes: 'scripts/**/*', name: 'terraform'
                     }
-                    stash includes: 'scripts/**/*', name: 'terraform'
                 }
             }
         }

--- a/ci/integration-tests-windows.groovy
+++ b/ci/integration-tests-windows.groovy
@@ -40,11 +40,13 @@ pipeline {
 
         stage("Launch AWS Cluster") {
             steps {
-                withCredentials(credentials) {
-                    script {
-                        master_ip = sh(script: 'cd scripts && ./launch_aws_cluster.sh', returnStdout: true).trim()
+                retry(5) {
+                    withCredentials(credentials) {
+                        script {
+                            master_ip = sh(script: 'cd scripts && ./launch_aws_cluster.sh', returnStdout: true).trim()
+                        }
+                        stash includes: 'scripts/**/*', name: 'terraform'
                     }
-                    stash includes: 'scripts/**/*', name: 'terraform'
                 }
             }
         }

--- a/scripts/launch_aws_cluster.sh
+++ b/scripts/launch_aws_cluster.sh
@@ -16,5 +16,5 @@ eval $(ssh-agent) >&2
 ssh-add $CLI_TEST_SSH_KEY_PATH >&2
 ssh-keygen -y -f $CLI_TEST_SSH_KEY_PATH > $HOME/.ssh/id_rsa.pub
 ./terraform init -no-color >&2
-./terraform  apply -auto-approve -no-color >&2 || (./terraform  destroy -auto-approve -no-color >&2 && false)
+./terraform  apply -auto-approve -no-color >&2
 ./terraform output master_public_ip


### PR DESCRIPTION
[Last nightly test](https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fmesosphere-dcos-cli%2Fcore%2Fintegration-tests-windows/detail/integration-tests-windows/1717/pipeline) failed due to issues with AWS cluster launch.
This PR will retry 5 times to create a cluster before CI will be marked
as failed.

Fixes: D2IQ-67815