### PR TITLE
Check list size to prevent index out of range

### DIFF
--- a/python/lib/dcoscli/dcoscli/test/marathon.py
+++ b/python/lib/dcoscli/dcoscli/test/marathon.py
@@ -405,7 +405,7 @@ def watch_for_overdue(max_count=300):
         cmd = ['dcos', 'marathon', 'debug', 'list', '--json']
         returncode, stdout, stderr = exec_command(cmd)
         result = json.loads(stdout.decode('utf-8'))
-        if result[0]['delay']['overdue']:
+        if len(result) > 0 and result[0]['delay']['overdue']:
             break
         else:
             count = count + 1


### PR DESCRIPTION
```
>           if result[0]['delay']['overdue']:
E           IndexError: list index out of range
```
Fixes: https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fmesosphere-dcos-cli%2Fcore%2Fintegration-tests-linux/detail/integration-tests-linux/2002/pipeline#step-50-log-518