### PR TITLE
[2.1] Refactor calico.go

### DIFF
--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
@@ -20,6 +22,7 @@ const invalidCertError = "An SSL error occurred. To configure your SSL settings,
 
 func main() {
 	ctx := cli.NewContext(cli.NewOsEnvironment())
+	ctx.Logger().SetLevel(pluginutil.Logger().Level)
 	if err := run(ctx); err != nil {
 		fmt.Fprintf(ctx.ErrOut(), "Error: %s\n", errorMessage(err))
 		os.Exit(1)

--- a/pkg/cmd/calico/calico.go
+++ b/pkg/cmd/calico/calico.go
@@ -9,211 +9,140 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dcos/dcos-core-cli/pkg/mesos"
+	"github.com/dcos/dcos-core-cli/pkg/networking"
+	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+
+	"github.com/spf13/cobra"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/dcos"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
-	"github.com/dcos/dcos-core-cli/pkg/mesos"
-	"github.com/dcos/dcos-core-cli/pkg/networking"
-	"github.com/spf13/cobra"
 )
 
-type stateResult struct {
-	state *mesos.State
-	err   error
-}
-
-type execContext = func(name string, arg ...string) *exec.Cmd
-
-func runCalicoCtl(cmdContext execContext, args []string, ctx api.Context, env []string) ([]byte, error) {
-	var command *exec.Cmd
-
-	cluster, _ := ctx.Cluster()
-	basePath := cluster.Dir()
-	calicoCtl := path.Join(basePath, "subcommands/dcos-core-cli/env/bin", "calicoctl")
-	if len(args) == 0 {
-		command = cmdContext(calicoCtl, "--help")
-	} else {
-		command = cmdContext(calicoCtl, args...)
-	}
-	command.Env = append(command.Env, append(os.Environ(), env...)...)
-	return command.CombinedOutput()
-}
-
-func request(url string) (*http.Response, error) {
-
-	probeClient := httpclient.New(strings.Replace(url, "https", "http", 1) + ":12379")
-
-	return probeClient.Get("")
-}
-
-func getMesosState(ctx api.Context) chan stateResult {
-	client, _ := mesosClient(ctx)
-	stateRes := make(chan stateResult)
-	go func() {
-		state, err := client.State()
-		stateRes <- stateResult{state, err}
-	}()
-	return stateRes
-}
-
-func getIps(ctx api.Context) chan map[string][]string {
-	cluster, _ := ctx.Cluster()
-	httpClient, _ := ctx.HTTPClient(cluster, httpclient.Timeout(3*time.Second))
-
-	ipsRes := make(chan map[string][]string)
-	// Ips Start
-	go func() {
-		ips := make(map[string][]string)
-		c := networking.NewClient(httpClient)
-		nodes, err := c.Nodes()
-		if err != nil {
-			ctx.Logger().Debug(err)
-		} else {
-			for _, node := range nodes {
-				ips[node.PrivateIP] = node.PublicIPs
-			}
-		}
-		ipsRes <- ips
-	}()
-	return ipsRes
-}
-
-func getEnvironment(ctx api.Context) []string {
-	var environmentVariables []string
-
-	cluster, err := ctx.Cluster()
-	if err != nil {
-		ctx.Logger().Debug(err)
-	}
-
-	httpClient, err := ctx.HTTPClient(cluster, httpclient.Timeout(3*time.Second))
-	dcosClient := dcos.NewClient(httpClient)
-
-	//State  start
-	stateRes := getMesosState(ctx)
-	// State End
-
-	ipsRes := getIps(ctx)
-
-	url := cluster.URL()
-	_, err = request(url)
-	if err != nil {
-		// Check out state start
-		stateResult := <-stateRes
-		if stateResult.err != nil {
-			ctx.Logger().Debug(stateResult.err)
-		}
-		state := stateResult.state
-		// Check out state end
-		ips := <-ipsRes
-		// master ip start
-		masterIPRes := make(chan string)
-		go func() {
-			if mesosMasters, err := mesos.NewClient(httpClient).Masters(); err == nil {
-				for _, master := range mesosMasters {
-					if master.IP == state.Hostname {
-						masterIPRes <- ips[master.IP][0]
-					}
-				}
-			} else {
-				ctx.Logger().Debug(err)
-
-			}
-		}()
-		masterIP := <-masterIPRes
-		url = "https://" + masterIP
-		_, err = request(url)
-		if err != nil {
-			ctx.Logger().Debug("Calicoctl is not able to connect to the gRPC port.")
-		}
-	}
-
-	if dcosVersion, err := dcosClient.Version(); err != nil {
-		ctx.Logger().Debug(err)
-	} else {
-		if dcosVersion.DCOSVariant != "enterprise" {
-			// master ip end
-			environmentVariables = append(
-				os.Environ(),
-				fmt.Sprintf("ETCD_CUSTOM_GRPC_METADATA=authorization:token=%s", cluster.ACSToken()),
-				fmt.Sprintf("ETCD_ENDPOINTS=%s:12379", url),
-			)
-			return environmentVariables
-		}
-	}
-
-	caFilePathRes := make(chan string)
-	go func() {
-		caClient := NewClient(httpClient)
-		cacert, caerr := caClient.getCaCertificate()
-
-		if caerr != nil {
-			ctx.Logger().Debug(caerr)
-		}
-
-		caFilePath := path.Join(cluster.Dir(), "dcos-ca.crt")
-		out, fileErr := os.Create(caFilePath)
-		if fileErr != nil {
-			ctx.Logger().Debug(fileErr)
-		}
-		out.WriteString(cacert)
-		out.Close()
-		if err != nil {
-			ctx.Logger().Debug(err)
-		}
-		caFilePathRes <- caFilePath
-	}()
-
-	caFilePath := <-caFilePathRes
-
-	environmentVariables = append(
-		os.Environ(),
-		fmt.Sprintf("ETCD_CUSTOM_GRPC_METADATA=authorization:token=%s", cluster.ACSToken()),
-		fmt.Sprintf("ETCD_ENDPOINTS=%s:12379", url),
-		fmt.Sprintf("ETCD_CA_CERT_FILE=%s", caFilePath),
-	)
-
-	return environmentVariables
-}
+const GrpcPort = ":12379"
 
 // NewCommand creates the `dcos package` subcommand.
 func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "calico [command]",
 		Short: "Calicoctl wrapper",
-		Run: func(cmd *cobra.Command, args []string) {
-			out, err := runCalicoCtl(exec.Command, args, ctx, getEnvironment(ctx))
-			fmt.Print(string(out))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			env, err := getEnvironment(ctx, GrpcPort)
 			if err != nil {
-				ctx.Logger().Debug(err)
-				fmt.Println(calicoError())
+				return err
 			}
-
+			return runCalicoCtl(args, ctx, env).Run()
 		},
 	}
 
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		out, err := runCalicoCtl(exec.Command, args[1:], ctx, getEnvironment(ctx))
-		fmt.Print(string(out))
+		err := runCalicoCtl(args[1:], ctx, nil).Run()
 		if err != nil {
-			ctx.Logger().Debug(err)
-			fmt.Println(calicoError())
+			fmt.Fprint(ctx.ErrOut(), err)
+			return
 		}
-	})
-
-	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		out, err := runCalicoCtl(exec.Command, os.Args[2:], ctx, getEnvironment(ctx))
-		fmt.Print(string(out))
-		if err != nil {
-			ctx.Logger().Debug(err)
-			fmt.Println(calicoError())
-		}
-		return nil
 	})
 
 	return cmd
 }
 
-func calicoError() string {
-	return "CalicoCtl exited with an error"
+func runCalicoCtl(args []string, ctx api.Context, env []string) *exec.Cmd {
+	var command *exec.Cmd
+	cluster, _ := ctx.Cluster()
+	basePath := cluster.Dir()
+	calicoCtl := path.Join(basePath, "subcommands/dcos-core-cli/env/bin", "calicoctl")
+	if len(args) == 0 {
+		command = exec.Command(calicoCtl, "--help")
+	} else {
+		args = append([]string{"-l", ctx.Logger().Level.String()}, args...)
+		command = exec.Command(calicoCtl, args...)
+	}
+	command.Stdin = ctx.Input()
+	command.Stdout = ctx.Out()
+	command.Stderr = ctx.ErrOut()
+	command.Env = append(os.Environ(), env...)
+	ctx.Logger().Debugf("%s %s %s", strings.Join(command.Env, " "), command.Path, strings.Join(command.Args, " "))
+	return command
+}
+
+func getEnvironment(ctx api.Context, grpcPort string) ([]string, error) {
+	cluster, err := ctx.Cluster()
+	if err != nil {
+		return nil, fmt.Errorf("can't get cluster: %s", err)
+	}
+
+	httpClient, err := ctx.HTTPClient(cluster, httpclient.Timeout(cluster.Timeout()))
+	if err != nil {
+		return nil, fmt.Errorf("can't get cluster client: %s", err)
+	}
+	dcosClient := dcos.NewClient(httpClient)
+
+	ctx.Logger().Debugln("Get leader private IP")
+	mesosClient := mesos.NewClient(httpClient)
+	leader, err := mesosClient.Leader()
+	if err != nil {
+		return nil, fmt.Errorf("could not get leader: %s", err)
+	}
+
+	ctx.Logger().Debugln("Get nodes public IPs")
+	c := networking.NewClient(httpClient)
+	nodes, err := c.Nodes()
+	if err != nil {
+		return nil, fmt.Errorf("could not get nodes: %s", err)
+	}
+
+	host := ""
+	for _, n := range nodes {
+		if n.PrivateIP == leader.IP && len(n.PublicIPs) > 0 {
+			host = n.PublicIPs[0]
+			break
+		}
+	}
+	_, err = request(host+grpcPort, cluster.Timeout())
+	if err != nil {
+		return nil, fmt.Errorf("calicoctl is not able to connect to the gRPC port: %s", err)
+	}
+
+	dcosVersion, err := dcosClient.Version()
+	if err != nil {
+		return nil, fmt.Errorf("could not get DC/OS version: %s", err)
+	}
+	if dcosVersion.DCOSVariant != "enterprise" {
+		return []string{
+			fmt.Sprintf("ETCD_CUSTOM_GRPC_METADATA=authorization:token=%s", cluster.ACSToken()),
+			fmt.Sprintf("ETCD_ENDPOINTS=%s%s", host, grpcPort),
+		}, nil
+	}
+
+	caClient := newClient(httpClient)
+	caCert, err := caClient.getCaCertificate()
+	if err != nil {
+		return nil, fmt.Errorf("could not get certificate: %s", err)
+	}
+
+	caFilePath := path.Join(cluster.Dir(), "dcos-ca.crt")
+	out, err := os.Create(caFilePath)
+	defer out.Close()
+	if err != nil {
+		return nil, fmt.Errorf("could not create CA file: %s", err)
+	}
+	_, err = out.WriteString(caCert)
+	if err != nil {
+		return nil, fmt.Errorf("could not write CA cert to file: %s", err)
+	}
+
+	return []string{
+		fmt.Sprintf("ETCD_CUSTOM_GRPC_METADATA=authorization:token=%s", cluster.ACSToken()),
+		fmt.Sprintf("ETCD_ENDPOINTS=%s%s", host, grpcPort),
+		fmt.Sprintf("ETCD_CA_CERT_FILE=%s", caFilePath),
+	}, nil
+}
+
+func request(url string, timeout time.Duration) (*http.Response, error) {
+	probeClient := pluginutil.HTTPClient(
+		"http://"+url,
+		httpclient.Timeout(timeout),
+	)
+	return probeClient.Get("")
 }

--- a/pkg/cmd/calico/calico_client.go
+++ b/pkg/cmd/calico/calico_client.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
-	"github.com/dcos/dcos-core-cli/pkg/mesos"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 )
 
 // Client is a calico client for DC/OS.
@@ -16,8 +13,8 @@ type Client struct {
 	http *httpclient.Client
 }
 
-// NewClient creates a new calico client.
-func NewClient(baseClient *httpclient.Client) *Client {
+// newClient creates a new calico client.
+func newClient(baseClient *httpclient.Client) *Client {
 	return &Client{
 		http: baseClient,
 	}
@@ -48,16 +45,4 @@ func httpResponseToError(resp *http.Response) error {
 	return &httpclient.HTTPError{
 		Response: resp,
 	}
-}
-
-func mesosClient(ctx api.Context) (*mesos.Client, error) {
-	cluster, err := ctx.Cluster()
-	if err != nil {
-		return nil, err
-	}
-	baseURL, _ := cluster.Config().Get("core.mesos_master_url").(string)
-	if baseURL == "" {
-		baseURL = cluster.URL() + "/mesos"
-	}
-	return mesos.NewClient(pluginutil.HTTPClient(baseURL)), nil
 }

--- a/pkg/cmd/calico/calico_test.go
+++ b/pkg/cmd/calico/calico_test.go
@@ -1,117 +1,166 @@
 package calico
 
 import (
-	"fmt"
+	"bytes"
+	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/mock"
-	"github.com/stretchr/testify/assert"
-)
-
-func Test_getMesosState(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/mesos/master/state", r.URL.String())
-		assert.Equal(t, "GET", r.Method)
-		w.Write([]byte(`{"Hostname":"127.0.0.1"}`))
-	}))
-	defer ts.Close()
-	ctx := newContext(ts)
-
-	data := <-getMesosState(ctx)
-	assert.Equal(t, data.state.Hostname, "127.0.0.1")
-}
-
-func Test_getIps(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/net/v1/nodes", r.URL.String())
-		assert.Equal(t, "GET", r.Method)
-		w.Write([]byte(`[{
-      "updated": "2020-03-14T13:37:00.000Z",
-      "public_ips": [
-        "127.0.0.2"
-      ],
-      "private_ip": "127.0.0.1",
-      "hostname": "ip-172-0-0-1"
-    }]`))
-	}))
-	defer ts.Close()
-	ctx := newContext(ts)
-
-	data := <-getIps(ctx)
-	wanted := map[string][]string{"127.0.0.1": {"127.0.0.2"}}
-	assert.Equal(t, wanted, data)
-}
-
-func newContext(ts *httptest.Server) *mock.Context {
-	env := mock.NewEnvironment()
-	ctx := mock.NewContext(env)
-	cluster := config.NewCluster(nil)
-	cluster.SetURL(ts.URL)
-	cluster.Config().SetPath("testDir/")
-	ctx.SetCluster(cluster)
-	return ctx
-}
-
-const (
-	testArg      = "--help"
-	testEnvValue = "GO_TEST_PROCESS_ENV=true"
 )
 
 func Test_runCalicoCtl(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	calicoCtlPath := path.Join(os.TempDir(), "subcommands/dcos-core-cli/env/bin/calicoctl")
+	tests := []struct {
+		args     []string
+		level    logrus.Level
+		expected *exec.Cmd
+	}{
+		{nil, logrus.DebugLevel, exec.Command(calicoCtlPath, "--help")},
+		{[]string{"--help"}, logrus.DebugLevel, exec.Command(calicoCtlPath, "-l", "debug", "--help")},
+		{[]string{"version"}, logrus.InfoLevel, exec.Command(calicoCtlPath, "-l", "info", "version")},
+		{[]string{"version", "-h"}, logrus.PanicLevel, exec.Command(calicoCtlPath, "-l", "panic", "version", "-h")},
+	}
+	for _, tt := range tests {
+		ctx, _ := newContext(ts)
+		ctx.Logger().SetLevel(tt.level)
+		t.Run(strings.Join(tt.args, " "), func(t *testing.T) {
+			cmd := runCalicoCtl(tt.args, ctx, []string{"A=1", "B=2"})
+			assert.Equal(t, tt.expected.Path, cmd.Path)
+			assert.Equal(t, tt.expected.Args, cmd.Args)
+			assert.Equal(t, append(os.Environ(), "A=1", "B=2"), cmd.Env)
+			assert.Equal(t, ctx.ErrOut(), cmd.Stderr)
+			assert.Equal(t, ctx.Input(), cmd.Stdin)
+			assert.Equal(t, ctx.Out(), cmd.Stdout)
+		})
+	}
+}
+
+func TestGetEnvForEnterprise(t *testing.T) {
+	grpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	u, err := url.Parse(grpcServer.URL)
+	require.NoError(t, err)
+	_, grpcPort, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mesos_dns/v1/hosts/leader.mesos":
+			w.Write([]byte(`[{"host": "leader.mesos.", "ip": "192.0.2.3"}]`))
+			return
+		case "/net/v1/nodes":
+			w.Write([]byte(`
+				[
+				   {"public_ips":[ "18.207.110.46"],"private_ip":"192.0.2.1"},
+				   {"public_ips":[], "private_ip":"192.0.2.2"},
+				   {"public_ips":["127.0.0.1"],"private_ip":"192.0.2.3"}
+				]`))
+			return
+		case "/dcos-metadata/dcos-version.json":
+			w.Write([]byte(`{"dcos-variant": "enterprise"}`))
+			return
+		case "/ca/dcos-ca.crt":
+			w.Write([]byte(`CERTIFICATE`))
+			return
+		}
+		t.Error("path is not supported: " + r.URL.Path)
 	}))
 	defer ts.Close()
-	ctx := newContext(ts)
-	stdout, err := runCalicoCtl(fakeExecCommandSuccess, []string{testArg}, ctx, []string{testEnvValue})
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	defer grpcServer.Close()
+	ctx, out := newContext(ts)
 
-	// Check to make sure the stdout is returned properly
-	stdoutStr := string(stdout)
-	testOutput := fmt.Sprintf("%v | %v %v", testEnvValue, path.Join("testDir", "subcommands/dcos-core-cli/env/bin/calicoctl"), testArg)
-	if stdoutStr != testOutput {
-		t.Errorf("stdout mismatch:\n%s\n vs \n%s", stdoutStr, testOutput)
-	}
+	env, err := getEnvironment(ctx, ":"+grpcPort)
+	assert.NoError(t, err)
+	cacertPath := path.Join(os.TempDir(), "dcos-ca.crt")
+	defer os.Remove(cacertPath)
+	assert.Equal(t, []string{
+		"ETCD_CUSTOM_GRPC_METADATA=authorization:token=",
+		"ETCD_ENDPOINTS=127.0.0.1:" + grpcPort,
+		"ETCD_CA_CERT_FILE=" + cacertPath,
+	}, env)
+	cert, err := ioutil.ReadFile(cacertPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "CERTIFICATE", string(cert))
+
+	output, err := ioutil.ReadAll(out)
+	assert.NoError(t, err)
+	assert.Equal(t, `level=debug msg="Get leader private IP"
+level=debug msg="Get nodes public IPs"
+`, string(output))
 
 }
 
-// TestShellProcessSuccess is a method that is called as a substitute for a shell command,
-// the GO_TEST_PROCESS flag ensures that if it is called as part of the test suite, it is
-// skipped.
-func TestShellProcessSuccess(t *testing.T) {
-	if os.Getenv("GO_TEST_PROCESS") != "1" {
-		return
-	}
-	// Print out the test value to stdout
-	var envValue string
-	env := os.Environ()
-	for _, v := range env {
-		if v == testEnvValue {
-			envValue = v
+func TestGetEnvForOSS(t *testing.T) {
+	grpcServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	u, err := url.Parse(grpcServer.URL)
+	require.NoError(t, err)
+	_, grpcPort, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mesos_dns/v1/hosts/leader.mesos":
+			w.Write([]byte(`[{"host": "leader.mesos.", "ip": "192.0.2.3"}]`))
+			return
+		case "/net/v1/nodes":
+			w.Write([]byte(`
+				[
+				   {"public_ips":[ "18.207.110.46"],"private_ip":"192.0.2.1"},
+				   {"public_ips":[], "private_ip":"192.0.2.2"},
+				   {"public_ips":["127.0.0.1"],"private_ip":"192.0.2.3"}
+				]`))
+			return
+		case "/dcos-metadata/dcos-version.json":
+			w.Write([]byte(`{"dcos-variant": "oss"}`))
+			return
 		}
-	}
-	args := os.Args
-	fmt.Fprintf(os.Stdout, "%v | %v", envValue, strings.Join(args[len(args)-2:], " "))
-	os.Exit(0)
+		t.Error("path is not supported: " + r.URL.Path)
+	}))
+	defer ts.Close()
+	defer grpcServer.Close()
+	ctx, out := newContext(ts)
+
+	env, err := getEnvironment(ctx, ":"+grpcPort)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"ETCD_CUSTOM_GRPC_METADATA=authorization:token=", "ETCD_ENDPOINTS=127.0.0.1:" + grpcPort}, env)
+
+	output, err := ioutil.ReadAll(out)
+	assert.NoError(t, err)
+	assert.Equal(t, `level=debug msg="Get leader private IP"
+level=debug msg="Get nodes public IPs"
+`, string(output))
+
 }
 
-// fakeExecCommandSuccess is a function that initialises a new exec.Cmd, one which will
-// simply call TestShellProcessSuccess rather than the command it is provided. It will
-// also pass through the command and its arguments as an argument to TestShellProcessSuccess
-func fakeExecCommandSuccess(command string, args ...string) *exec.Cmd {
-	cs := []string{"-test.run=TestShellProcessSuccess", "--", command}
-	cs = append(cs, args...)
-	arg := os.Args[0]
-	cmd := exec.Command(arg, cs...)
-	cmd.Env = []string{"GO_TEST_PROCESS=1"}
-	return cmd
+func newContext(ts *httptest.Server) (*mock.Context, *bytes.Buffer) {
+	out := new(bytes.Buffer)
+	env := mock.NewEnvironment()
+	env.Out = out
+	env.ErrOut = out
+	ctx := mock.NewContext(env)
+	// Use tempdir as cluster dir to check if path if properly created
+	conf := config.Empty()
+	conf.SetPath(path.Join(os.TempDir(), "conf.toml"))
+	cluster := config.NewCluster(conf)
+	cluster.SetURL(ts.URL)
+	ctx.SetCluster(cluster)
+	ctx.Logger().Out = out
+	ctx.Logger().SetLevel(logrus.DebugLevel)
+	ctx.Logger().SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	return ctx, out
 }

--- a/pkg/marathon/mocks/marathon.go
+++ b/pkg/marathon/mocks/marathon.go
@@ -5,6 +5,7 @@ package mocks
 import (
 	"net/url"
 	"time"
+
 	"github.com/gambol99/go-marathon"
 )
 
@@ -16,7 +17,7 @@ type MarathonMock struct {
 	AllTasksInvocations                  int
 	AllTasksFn                           func(*marathon.AllTasksOpts) (*marathon.Tasks, error)
 	ApiPostInvocations                   int
-	ApiPostFn                            func(string, interface {}, interface {}) error
+	ApiPostFn                            func(string, interface{}, interface{}) error
 	ApplicationInvocations               int
 	ApplicationFn                        func(string) (*marathon.Application, error)
 	ApplicationByInvocations             int
@@ -150,7 +151,7 @@ func (m *MarathonMock) AllTasks(p0 *marathon.AllTasksOpts) (*marathon.Tasks, err
 	return m.AllTasksFn(p0)
 }
 
-func (m *MarathonMock) ApiPost(p0 string, p1 interface {}, p2 interface {}) error {
+func (m *MarathonMock) ApiPost(p0 string, p1 interface{}, p2 interface{}) error {
 	m.ApiPostInvocations++
 	return m.ApiPostFn(p0, p1, p2)
 }

--- a/pkg/mesos/client.go
+++ b/pkg/mesos/client.go
@@ -169,6 +169,9 @@ func (c *Client) Leader() (*Master, error) {
 		if len(hosts) > 1 {
 			return nil, fmt.Errorf("expecting one leader. Got %d", len(hosts))
 		}
+		if len(hosts) == 0 {
+			return nil, fmt.Errorf("no leader found")
+		}
 		return &hosts[0], err
 	default:
 		return nil, httpResponseToError(resp)


### PR DESCRIPTION
* Reorder functions
* Remove async code (user can wait)
* Simplify the code
* Extract GRPC port to constant
* Use leader public IP instead of obtaining it from state
* Handle errors
* Print error not just "CalicoCtl exited with an error"
* Fix logging for all components

Fixes: https://jira.d2iq.com/browse/COPS-6353
Backports: #487