### PR TITLE
Fix flag parsing for calico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.1-patch.x
 
+## 2.1-patch.3
+
+* Fixes
+    * Fix calico flag parsing
+
 ## 2.1-patch.2
 
 * Breaking changes

--- a/pkg/cmd/calico/calico.go
+++ b/pkg/cmd/calico/calico.go
@@ -42,6 +42,8 @@ func NewCommand(ctx api.Context) *cobra.Command {
 		}
 	})
 
+	cmd.DisableFlagParsing = true
+
 	return cmd
 }
 
@@ -115,9 +117,10 @@ func getEnvironment(ctx api.Context, grpcPort string) ([]string, error) {
 	tlsCAPath, ok := os.LookupEnv("DCOS_TLS_CA_PATH")
 	if !ok {
 		return nil, fmt.Errorf("DCOS_TLS_CA_PATH is not defined. " +
-			"Calico requires secure connection. " +
-			"Do NOT use --insecure flag with dcos cluster setup, " +
-			"--no-check should be used instead")
+			"Calico requires secure connection and CA certificate file.\n" +
+			"DON'T use --insecure flag with dcos cluster setup, " +
+			"--no-check should be used instead\n" +
+			"Run: dcos cluster setup https://" + host)
 	}
 
 	if err := probeGrpc("https://" + host + grpcPort); err != nil {

--- a/python/lib/dcoscli/tests/integrations/test_calico.py
+++ b/python/lib/dcoscli/tests/integrations/test_calico.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest
+
 from dcoscli.test.common import assert_command
 
 
@@ -5,3 +9,14 @@ def test_calico_version():
     with open('tests/data/calico/version.txt') as content:
         assert_command(['dcos', 'calico', 'version'],
                        stdout=content.read().encode('utf-8'))
+
+
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason='Different error message on windows')
+def test_calico_flag_parsing():
+    assert_command(['dcos', 'calico', 'apply', '-f', 'not-existing-file.yml'],
+                   returncode=1,
+                   stderr=b'Failed to execute command: '
+                          b'open not-existing-file.yml: '
+                          b'no such file or directory\n'
+                          b'Error: exit status 1\n')


### PR DESCRIPTION
By default Cobra try to parse flags. For calico there are no flags since – just a wrapper. We need to disable flag parsing.

Refs: https://jira.d2iq.com/browse/COPS-6353
Backports: https://github.com/dcos/dcos-core-cli/pull/497