### PR TITLE
Fix panic on empty APP

### DIFF
--- a/pkg/marathon/client.go
+++ b/pkg/marathon/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	goMarathon "github.com/gambol99/go-marathon"
+	"github.com/sirupsen/logrus"
 )
 
 const UnfulfilledRole = "UnfulfilledRole"
@@ -57,6 +58,9 @@ func NewClient(ctx api.Context) (*Client, error) {
 	config := goMarathon.NewDefaultConfig()
 	config.URL = baseURL
 	config.HTTPClient = pluginutil.NewHTTPClient()
+	if ctx.Logger().IsLevelEnabled(logrus.InfoLevel) {
+		config.LogOutput = ctx.Logger().Out
+	}
 
 	client, err := goMarathon.NewClient(config)
 	if err != nil {
@@ -80,7 +84,12 @@ func (c *Client) AddApp(ctx api.Context, appLocation string) (*goMarathon.Applic
 		return nil, err
 	}
 
-	existingApp, err := c.API.ApplicationBy(app["id"].(string), &goMarathon.GetAppOpts{})
+	id, ok := app["id"]
+	if !ok {
+		return nil, fmt.Errorf("application ID must be set")
+	}
+
+	existingApp, err := c.API.ApplicationBy(id.(string), &goMarathon.GetAppOpts{})
 	if err != nil {
 		if apiErr, ok := err.(*goMarathon.APIError); !ok {
 			return nil, err

--- a/pkg/marathon/client_test.go
+++ b/pkg/marathon/client_test.go
@@ -376,33 +376,30 @@ func jsonEqual(t *testing.T, expected interface{}, actual interface{}) {
 	assert.JSONEq(t, string(expectedJSON), string(actualJSON))
 }
 
-func TestAddAppWithEmptyInput(t *testing.T) {
-	client := &Client{API: &marathonmocks.MarathonMock{}}
-	ctx := mock.NewContext(&cli.Environment{Input: strings.NewReader("")})
+func TestAddAppWith(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		file  string
+		err   string
+	}{
+		{name: "empty app", input: "{}", err: "application ID must be set"},
+		{name: "no id", input: `{"foo":"bar"}`, err: "application ID must be set"},
+		{name: "no input", err: "unexpected end of JSON input"},
+		{name: "no exiting file", file: "/this/does/not/exist", err: "cannot read app definition"},
+		{name: "usuported schema", file: "fwtp://example.org/whateva", err: "cannot read app definition"},
+		{name: "broken URL", file: "ft p://example.org/whateva", err: "cannot read app definition"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &Client{API: &marathonmocks.MarathonMock{}}
+			ctx := mock.NewContext(&cli.Environment{Input: strings.NewReader(test.input)})
 
-	newApp, err := client.AddApp(ctx, "")
-	assert.Error(t, err, nil)
-	_, ok := err.(*json.SyntaxError)
-	assert.True(t, ok)
-	assert.Nil(t, newApp)
-}
-
-func TestAddAppWithNonExistingFile(t *testing.T) {
-	client := &Client{API: &marathonmocks.MarathonMock{}}
-	ctx := mock.NewContext(nil)
-
-	newApp, err := client.AddApp(ctx, "/this/does/not/exist")
-	assert.Equal(t, ErrCannotReadAppDefinition, err, nil)
-	assert.Nil(t, newApp)
-}
-
-func TestAddAppWithUnsupportedScheme(t *testing.T) {
-	client := &Client{API: &marathonmocks.MarathonMock{}}
-	ctx := mock.NewContext(nil)
-
-	newApp, err := client.AddApp(ctx, "ftp://example.org/whateva")
-	assert.Error(t, err, nil)
-	assert.Nil(t, newApp)
+			newApp, err := client.AddApp(ctx, test.file)
+			assert.EqualError(t, err, test.err)
+			assert.Nil(t, newApp)
+		})
+	}
 }
 
 func TestAddAppWithHTTPURL(t *testing.T) {
@@ -438,15 +435,6 @@ func TestAddAppWithHTTPURL(t *testing.T) {
 	assert.Equal(t, 1, marathonMock.ApplicationByInvocations, "Expected ApplicationBy to be invoked once")
 	assert.Equal(t, 1, marathonMock.ApiPostInvocations, "Expected ApiPost to be invoked once")
 	assert.Equal(t, &goMarathon.Application{}, newApp)
-}
-
-func TestAddAppWithBrokenURL(t *testing.T) {
-	client := &Client{API: &marathonmocks.MarathonMock{}}
-	ctx := mock.NewContext(nil)
-
-	newApp, err := client.AddApp(ctx, "ft p://example.org/whateva")
-	assert.Error(t, err, nil)
-	assert.Nil(t, newApp)
 }
 
 func TestAddApp(t *testing.T) {


### PR DESCRIPTION
Fixes panic when app does not contain ID.
Enable logging for Marathon client

Refs: https://jira.d2iq.com/browse/COPS-1794
Backports: #509