### PR TITLE
Use timeout from dcos config for diagnostic download (#512)

### DIFF
--- a/pkg/cmd/diagnostics/diagnostics.go
+++ b/pkg/cmd/diagnostics/diagnostics.go
@@ -2,6 +2,7 @@ package diagnostics
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/dcos/dcos-cli/api"
@@ -18,7 +19,7 @@ func NewCommand(ctx api.Context) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newDiagnosticsListCommand(ctx),
-		newDiagnosticsDownloadCommand(),
+		newDiagnosticsDownloadCommand(ctx),
 		newDiagnosticsCreateCommand(ctx),
 		newDiagnosticsDeleteCommand(ctx),
 		newDiagnosticsWaitCommand(ctx),
@@ -51,4 +52,16 @@ func latestBundle(client *diagnostics.Client) (*diagnostics.Bundle, error) {
 	}
 
 	return &bundle, nil
+}
+
+func client(ctx api.Context) (*diagnostics.Client, error) {
+	cluster, err := ctx.Cluster()
+	if err != nil {
+		return nil, fmt.Errorf("could not get cluster: %s", err)
+	}
+	c, err := ctx.HTTPClient(cluster)
+	if err != nil {
+		return nil, fmt.Errorf("could not create HTTP client: %s", err)
+	}
+	return diagnostics.NewClient(c), nil
 }

--- a/pkg/cmd/diagnostics/diagnostics_create.go
+++ b/pkg/cmd/diagnostics/diagnostics_create.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dcos/dcos-cli/api"
 	diagnostics "github.com/dcos/dcos-core-cli/pkg/diagnostics/v2"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +14,10 @@ func newDiagnosticsCreateCommand(ctx api.Context) *cobra.Command {
 		Use:   "create",
 		Short: "Create a diagnostics bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := pluginutil.HTTPClient("")
-			client := diagnostics.NewClient(c)
+			client, err := client(ctx)
+			if err != nil {
+				return err
+			}
 			opts := diagnostics.Options{
 				Masters: masters || !masters && !agents,
 				Agents:  agents || !masters && !agents,

--- a/pkg/cmd/diagnostics/diagnostics_delete.go
+++ b/pkg/cmd/diagnostics/diagnostics_delete.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/dcos/dcos-cli/api"
-	diagnostics "github.com/dcos/dcos-core-cli/pkg/diagnostics/v2"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +13,10 @@ func newDiagnosticsDeleteCommand(ctx api.Context) *cobra.Command {
 		Short: "Delete a diagnostics bundle",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := pluginutil.HTTPClient("")
-			client := diagnostics.NewClient(c)
+			client, err := client(ctx)
+			if err != nil {
+				return err
+			}
 			id := args[0]
 
 			if err := client.Delete(id); err != nil {

--- a/pkg/cmd/diagnostics/diagnostics_download.go
+++ b/pkg/cmd/diagnostics/diagnostics_download.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	diagnostics "github.com/dcos/dcos-core-cli/pkg/diagnostics/v2"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
-func newDiagnosticsDownloadCommand() *cobra.Command {
+func newDiagnosticsDownloadCommand(ctx api.Context) *cobra.Command {
 	var outputPath string
 
 	cmd := &cobra.Command{
@@ -18,8 +17,10 @@ func newDiagnosticsDownloadCommand() *cobra.Command {
 		Short: "Download diagnostics bundle",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := pluginutil.HTTPClient("")
-			client := diagnostics.NewClient(c)
+			client, err := client(ctx)
+			if err != nil {
+				return err
+			}
 
 			var id string
 			if len(args) == 0 {

--- a/pkg/cmd/diagnostics/diagnostics_list.go
+++ b/pkg/cmd/diagnostics/diagnostics_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/cli"
 	diagnostics "github.com/dcos/dcos-core-cli/pkg/diagnostics/v2"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
@@ -19,8 +18,10 @@ func newDiagnosticsListCommand(ctx api.Context) *cobra.Command {
 		Use:   "list",
 		Short: "List available bundles",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := pluginutil.HTTPClient("")
-			client := diagnostics.NewClient(c)
+			client, err := client(ctx)
+			if err != nil {
+				return err
+			}
 			bundles, err := client.List()
 			if err != nil {
 				return err

--- a/pkg/cmd/diagnostics/diagnostics_wait.go
+++ b/pkg/cmd/diagnostics/diagnostics_wait.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/dcos/dcos-cli/api"
 	diagnostics "github.com/dcos/dcos-core-cli/pkg/diagnostics/v2"
-	"github.com/dcos/dcos-core-cli/pkg/pluginutil"
 	"github.com/spf13/cobra"
 )
 
@@ -17,8 +16,10 @@ func newDiagnosticsWaitCommand(ctx api.Context) *cobra.Command {
 		Short: "Wait until the given bundle is completed",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c := pluginutil.HTTPClient("")
-			client := diagnostics.NewClient(c)
+			client, err := client(ctx)
+			if err != nil {
+				return err
+			}
 
 			// this seemed to be the easiest way to manage using two different methods
 			// of getting the right bundle depending on the arguments

--- a/python/lib/dcoscli/tests/integrations/test_marathon.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon.py
@@ -335,8 +335,8 @@ def test_killing_app():
         watch_all_deployments()
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'app', 'kill', 'zero-instance-app'])
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         out = stdout.decode()
         assert out.startswith('Killed tasks: ')
         out = out.strip('Killed tasks: ')
@@ -835,8 +835,8 @@ def _stop_task(task_id, wipe=None, expect_success=True):
     returncode, stdout, stderr = exec_command(cmd)
 
     if expect_success:
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         result = json.loads(stdout.decode('utf-8'))
         assert result['id'] == task_id
     else:
@@ -852,8 +852,8 @@ def _kill_task(task_ids, scale=None, wipe=None, expect_success=True):
     returncode, stdout, stderr = exec_command(cmd)
 
     if expect_success:
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         result = json.loads(stdout.decode('utf-8'))
         if scale:
             assert 'deploymentId' in result

--- a/python/lib/dcoscli/tests/integrations/test_marathon_debug.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon_debug.py
@@ -20,8 +20,8 @@ def test_debug_list_json():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'debug', 'list', '--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         decoded = stdout.decode()
         assert 'overdue' in decoded
@@ -56,8 +56,8 @@ def test_debug_list_pod_json():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'debug', 'list', '--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         decoded = stdout.decode()
         assert 'overdue' in decoded
@@ -72,8 +72,8 @@ def test_debug_summary():
             returncode, stdout, stderr = exec_command(
                 ['dcos', 'marathon', 'debug', 'summary', '/stuck-sleep'])
 
-            assert returncode == 0
             assert stderr == b''
+            assert returncode == 0
 
             decoded = stdout.decode()
             assert 'CONSTRAINTS' in decoded
@@ -87,8 +87,8 @@ def test_debug_summary_json():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'debug', 'summary', '/stuck-sleep', '--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         decoded = stdout.decode().replace(' ', '').replace('\n', '')
         assert '"reason":"UnfulfilledConstraint"' in decoded
@@ -103,8 +103,8 @@ def test_debug_summary_pod():
             returncode, stdout, stderr = exec_command(
                 ['dcos', 'marathon', 'debug', 'summary', '/stuck-pod'])
 
-            assert returncode == 0
             assert stderr == b''
+            assert returncode == 0
 
             decoded = stdout.decode()
             assert 'CONSTRAINTS' in decoded
@@ -120,8 +120,8 @@ def test_debug_summary_pod_json():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'debug', 'summary', '/stuck-pod', '--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         decoded = stdout.decode().replace(' ', '').replace('\n', '')
         assert '"reason":"UnfulfilledConstraint"' in decoded
@@ -169,8 +169,8 @@ def test_debug_details_json():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'debug', 'details', '/stuck-sleep', '--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         decoded = stdout.decode().replace(' ', '').replace('\n', '')
         assert '"reason":"UnfulfilledConstraint"' in decoded
@@ -188,8 +188,8 @@ def test_debug_details_pod_json():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'debug', 'details', '/stuck-pod', '--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         decoded = stdout.decode().replace(' ', '').replace('\n', '')
         assert '"reason":"UnfulfilledConstraint"' in decoded

--- a/python/lib/dcoscli/tests/integrations/test_marathon_pod.py
+++ b/python/lib/dcoscli/tests/integrations/test_marathon_pod.py
@@ -164,8 +164,8 @@ def _wait_for_instances(expected_instances, max_attempts=10):
     for attempt in range(max_attempts):
         returncode, stdout, stderr = exec_command(_POD_LIST_CMD + ['--json'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
         status_json = json.loads(stdout.decode('utf-8'))
         actual_instances = {pod_obj['id']: len(pod_obj.get('instances', []))

--- a/python/lib/dcoscli/tests/integrations/test_package.py
+++ b/python/lib/dcoscli/tests/integrations/test_package.py
@@ -381,8 +381,8 @@ def test_install_specific_version():
 
         returncode, stdout, stderr = exec_command(
             ['dcos', 'package', 'list', 'helloworld', '--json'])
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         assert json.loads(stdout.decode('utf-8'))[0]['version'] == "0.1.0"
 
 

--- a/python/lib/dcoscli/tests/integrations/test_ssl.py
+++ b/python/lib/dcoscli/tests/integrations/test_ssl.py
@@ -25,8 +25,8 @@ def test_dont_verify_ssl_with_config(env):
     with update_config('core.ssl_verify', 'false', env):
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'app', 'list'], env)
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
 
 
 def test_verify_ssl_without_cert_env_var(env):

--- a/python/lib/dcoscli/tests/integrations/test_task.py
+++ b/python/lib/dcoscli/tests/integrations/test_task.py
@@ -320,8 +320,8 @@ def test_download_sandbox():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'task', 'download', 'download-app'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         assert os.path.exists(tmp + '/test')
         assert os.path.exists(tmp + '/test/test1')
 
@@ -339,8 +339,8 @@ def test_download_sandbox_to_target():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'task', 'download', 'download-app', targetdir])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         assert os.path.exists(tmp + '/sandbox')
 
 
@@ -354,8 +354,8 @@ def test_download_single_file():
         returncode, stdout, stderr = exec_command(
             ['dcos', 'task', 'download', 'download-app', '/test/test1'])
 
-        assert returncode == 0
         assert stderr == b''
+        assert returncode == 0
         assert os.path.exists(tmp + '/test1')
 
         file = open(tmp + '/test1', 'r')


### PR DESCRIPTION
* Use timeout from dcos config for diagnostic download

Fixes: https://jira.d2iq.com/browse/COPS-6584

* Check stderr before exit code

It's easier to debug failing test when we have stderr

Backports:  (#512)