### PR TITLE
Release 2.2-patch.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.2-patch.x
 
+## 2.2-patch.0
+
 * Breaking changes
 
   * Update Go to 1.15 – support only macOS 10.12 Sierra or later (#490)


### PR DESCRIPTION
* Breaking changes

  * Update Go to 1.15 – support only macOS 10.12 Sierra or later (#490)
  * Require TLS 1.2 or above (#490)
  * `dcos service shutdown` asks for confirmation unless `--yes` flag specified (#506).