### PR TITLE
D2IQ-72612 parse dependencies

### DIFF
--- a/ci/integration-tests-windows.groovy
+++ b/ci/integration-tests-windows.groovy
@@ -63,13 +63,15 @@ pipeline {
             steps {
                 unstash "dcos-exe"
                 unstash "dcos-${os}"
-                withEnv(["DCOS_TEST_URL=${master_ip}", "OS=${os}"]) {
+                withEnv(["DCOS_TEST_URL=${master_ip}", "OS=${os}", "BUILD_NUMBER=${BUILD_NUMBER}"]) {
                     withCredentials(credentials) {
                         bat '''
                             bash -exc " \
                             export PYTHONIOENCODING=utf-8; \
                             export CLI_TEST_SSH_USER=centos; \
                             export CLI_TEST_MASTER_PROXY=1; \
+                            export DCOS_DIR=$PWD/$BUILD_NUMBER; \
+                            mkdir -p $DCOS_DIR; \
                             mkdir -p build/windows; \
                             make python; \
                             python scripts/plugin/package_plugin.py; \
@@ -81,7 +83,8 @@ pipeline {
                             dcos cluster remove --all; \
                             dcos cluster setup --no-check ${DCOS_TEST_URL}; \
                             dcos plugin add -u ../../../build/$OS/dcos-core-cli.zip; \
-                            ./env/Scripts/pytest -vv -x --durations=10 -p no:cacheprovider tests/integrations --junitxml=tests.xml"'''
+                            ./env/Scripts/pytest -vv -x --durations=10 -p no:cacheprovider tests/integrations --junitxml=tests.xml"; \
+                            rm -rf $DCOS_DIR'''
                     }
                 }
             }

--- a/pkg/cmd/job/job_test.go
+++ b/pkg/cmd/job/job_test.go
@@ -13,6 +13,7 @@ func TestParseJSONJob(t *testing.T) {
 {
 	"id": "sleepy-test-docker",
 	"description": "A job that sleeps",
+	"dependencies": [{ "id": "MOAJ" }],
 	"run": {
 		"cmd": "echo 'Snoozing ...'; sleep 10; echo 'Awake now!'",
 		"cpus": 2,
@@ -42,4 +43,7 @@ func TestParseJSONJob(t *testing.T) {
 	assert.Equal(t, "alpine:latest", job.Run.Docker.Image)
 	assert.True(t, job.Run.Docker.ForcePullImage)
 	assert.True(t, job.Run.Docker.Privileged)
+
+	// Dependencies
+	assert.Equal(t, "MOAJ", job.Dependencies[0].ID)
 }

--- a/pkg/metronome/types.go
+++ b/pkg/metronome/types.go
@@ -9,9 +9,10 @@ const notAvailable = "N/A"
 
 // Job represents a Job returned by the Metronome API.
 type Job struct {
-	ID          string            `json:"id"`
-	Description string            `json:"description"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	ID           string            `json:"id"`
+	Dependencies []dependency      `json:"dependencies,omitempty"`
+	Description  string            `json:"description"`
+	Labels       map[string]string `json:"labels,omitempty"`
 	// The run property of a Job represents the run configuration for that Job
 	Run struct {
 		Args                       []string               `json:"args,omitempty"`
@@ -45,6 +46,10 @@ type artifact struct {
 	Executable bool   `json:"executable"`
 	Extract    bool   `json:"extract"`
 	Cache      bool   `json:"cache"`
+}
+
+type dependency struct {
+	ID string `json:"id"`
 }
 
 type docker struct {


### PR DESCRIPTION
DC/OS 2.2 brings Jobs with Dependencies.
Let's teach CLI how to pass those on to the Metronome-API.

closes D2IQ-72612